### PR TITLE
Refactor:テストコードのSQL操作のヘルパー化

### DIFF
--- a/backend/tests/order_integration_test.go
+++ b/backend/tests/order_integration_test.go
@@ -159,7 +159,7 @@ func seedHappyPath(t *testing.T) (userID int64, productID int64) {
 
 	// テスト後に全データ掃除
 	t.Cleanup(func() {
-		testDB.Exec(`TRUNCATE TABLE order_items, orders, cart_items, carts, products, categories, users RESTART IDENTITY CASCADE`)
+		cleanupOrderRelatedTables(t)
 	})
 
 	return userID, productID
@@ -184,39 +184,11 @@ func TestCreateOrderHandler_HappyPath(t *testing.T) {
 
 	assert.Equal(t, http.StatusCreated, w.Code)
 
-	// 1) orderが1件作成される
-	var orderCount int
-	err := testDB.QueryRow(`SELECT COUNT(*) FROM orders WHERE user_id = $1`, userID).Scan(&orderCount)
-	assert.NoError(t, err)
-	assert.Equal(t, 1, orderCount)
-
-	// 2) order_itemsが1件作成される
-	var orderItemCount int
-	err = testDB.QueryRow(`
-		SELECT COUNT(*)
-		FROM order_items oi
-		JOIN orders o ON o.id = oi.order_id
-		WHERE o.user_id =$1
-	`, userID).Scan(&orderItemCount)
-	assert.NoError(t, err)
-	assert.Equal(t, 1, orderItemCount)
-
-	// 3) products.stock_quantityが10 -> 8に減る
-	var stock int32
-	err = testDB.QueryRow(`SELECT stock_quantity FROM products WHERE id =$1`, productID).Scan(&stock)
-	assert.NoError(t, err)
-	assert.Equal(t, int32(8), stock)
-
-	// 4) cart_itemsが0件
-	var cartItemCount int
-	err = testDB.QueryRow(`
-		SELECT COUNT(*)
-		FROM cart_items ci
-		JOIN carts c ON c.id = ci.cart_id
-		WHERE c.user_id = $1
-	`, userID).Scan(&cartItemCount)
-	assert.NoError(t, err)
-	assert.Equal(t, 0, cartItemCount)
+	// 注文が正しく処理され、在庫が減少(10-2=8),カートがクリアされることを検証
+	assertOrderCountByUser(t, userID, 1)
+	assertOrderItemCountByUser(t, userID, 1)
+	assertProductStockByID(t, productID, 8)
+	assertCartItemCountByUser(t, userID, 0)
 
 }
 
@@ -239,15 +211,13 @@ func seedEmptyCart(t *testing.T) int64 {
 	}
 
 	t.Cleanup(func() {
-		_, _ = testDB.Exec(`
-            TRUNCATE TABLE order_items, orders, cart_items, carts, products, categories, users
-            RESTART IDENTITY CASCADE
-        `)
+		cleanupOrderRelatedTables(t)
 	})
 
 	return userID
 }
 
+// 在庫1個の商品[SKU_00S-001]に対して、数量5の注文をリクエストする
 func seedOutOfStock(t *testing.T) int64 {
 	t.Helper()
 
@@ -298,10 +268,7 @@ func seedOutOfStock(t *testing.T) int64 {
 	}
 
 	t.Cleanup(func() {
-		_, _ = testDB.Exec(`
-            TRUNCATE TABLE order_items, orders, cart_items, carts, products, categories, users
-            RESTART IDENTITY CASCADE
-        `)
+		cleanupOrderRelatedTables(t)
 	})
 
 	return userID
@@ -341,13 +308,7 @@ func TestCreateOrderHandler(t *testing.T) {
 			expectedStatus: http.StatusBadRequest,
 			expectedErrMsg: "カートが空です",
 			assertDB: func(t *testing.T, userID int64) {
-				t.Helper()
-				var orderCount int
-				err := testDB.QueryRow(`
-					SELECT COUNT(*) FROM orders WHERE user_id = $1	
-				`, userID).Scan(&orderCount)
-				assert.NoError(t, err)
-				assert.Equal(t, 0, orderCount)
+				assertOrderCountByUser(t, userID, 0)
 			},
 		},
 		{
@@ -357,32 +318,10 @@ func TestCreateOrderHandler(t *testing.T) {
 			expectedStatus: http.StatusConflict,
 			expectedErrMsg: "在庫不足です",
 			assertDB: func(t *testing.T, userID int64) {
-				t.Helper()
-				var orderCount int
-				err := testDB.QueryRow(`
-					SELECT COUNT(*) FROM orders WHERE user_id = $1
-				`, userID).Scan(&orderCount)
-				assert.NoError(t, err)
-				assert.Equal(t, 0, orderCount)
-
-				var orderItemCount int
-				err = testDB.QueryRow(`SELECT COUNT(*) FROM order_items`).Scan(&orderItemCount)
-				assert.NoError(t, err)
-				assert.Equal(t, 0, orderItemCount)
-
-				var stock int32
-				err = testDB.QueryRow(`
-					SELECT stock_quantity FROM products WHERE sku = 'SKU_00S-001'
-				`).Scan(&stock)
-				assert.NoError(t, err)
-				assert.Equal(t, int32(1), stock)
-
-				var cartItemCount int
-				err = testDB.QueryRow(`
-					SELECT COUNT(*) FROM cart_items ci JOIN carts c ON c.id = ci.cart_id WHERE c.user_id = $1
-				`, userID).Scan(&cartItemCount)
-				assert.NoError(t, err)
-				assert.Equal(t, 1, cartItemCount)
+				assertOrderCountByUser(t, userID, 0)
+				assertOrderItemCountByUser(t, userID, 0)
+				assertProductStockBySKU(t, "SKU_00S-001", 1)
+				assertCartItemCountByUser(t, userID, 1)
 			},
 		},
 		{
@@ -392,13 +331,8 @@ func TestCreateOrderHandler(t *testing.T) {
 			expectedStatus: http.StatusBadRequest,
 			expectedErrMsg: "カートが空です",
 			assertDB: func(t *testing.T, userID int64) {
-				t.Helper()
-				var orderCount int
-				err := testDB.QueryRow(`
-					SELECT COUNT(*) FROM orders WHERE user_id = $1
-				`, userID).Scan(&orderCount)
-				assert.NoError(t, err)
-				assert.Equal(t, 0, orderCount)
+				// orderが0件であること
+				assertOrderCountByUser(t, userID, 0)
 			},
 		},
 		{
@@ -408,16 +342,8 @@ func TestCreateOrderHandler(t *testing.T) {
 			expectedStatus: http.StatusBadRequest,
 			expectedErrMsg: "カートが空です",
 			assertDB: func(t *testing.T, userID int64) {
-				t.Helper()
-
-				var orderCount int
-				err := testDB.QueryRow(`
-                    SELECT COUNT(*)
-                    FROM orders
-                    WHERE user_id = $1
-                `, userID).Scan(&orderCount)
-				assert.NoError(t, err)
-				assert.Equal(t, 0, orderCount)
+				// orderが0件であること
+				assertOrderCountByUser(t, userID, 0)
 			},
 		},
 	}

--- a/backend/tests/order_integration_test.go
+++ b/backend/tests/order_integration_test.go
@@ -331,7 +331,6 @@ func TestCreateOrderHandler(t *testing.T) {
 			expectedStatus: http.StatusBadRequest,
 			expectedErrMsg: "カートが空です",
 			assertDB: func(t *testing.T, userID int64) {
-				// orderが0件であること
 				assertOrderCountByUser(t, userID, 0)
 			},
 		},
@@ -342,7 +341,6 @@ func TestCreateOrderHandler(t *testing.T) {
 			expectedStatus: http.StatusBadRequest,
 			expectedErrMsg: "カートが空です",
 			assertDB: func(t *testing.T, userID int64) {
-				// orderが0件であること
 				assertOrderCountByUser(t, userID, 0)
 			},
 		},

--- a/backend/tests/sql_assert_helper_test.go
+++ b/backend/tests/sql_assert_helper_test.go
@@ -1,4 +1,4 @@
-// go:build integration
+//go:build integration
 
 package tests
 

--- a/backend/tests/sql_assert_helper_test.go
+++ b/backend/tests/sql_assert_helper_test.go
@@ -1,0 +1,78 @@
+// go:build integration
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// order件数
+func assertOrderCountByUser(t *testing.T, userID int64, want int) {
+	t.Helper()
+	var got int
+	err := testDB.QueryRow(`SELECT COUNT(*) FROM orders WHERE user_id=$1`, userID).Scan(&got)
+	assert.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+// orderItem件数
+func assertOrderItemCountByUser(t *testing.T, userID int64, want int) {
+	t.Helper()
+	var got int
+	err := testDB.QueryRow(`
+		SELECT COUNT(*)
+		FROM order_items oi
+		JOIN orders o ON o.id = oi.order_id
+		WHERE o.user_id = $1
+	`, userID).Scan(&got)
+	assert.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+// cartItem件数
+func assertCartItemCountByUser(t *testing.T, userID int64, want int) {
+	t.Helper()
+	var got int
+	err := testDB.QueryRow(`
+		SELECT COUNT(*)
+		FROM cart_items ci
+		JOIN carts c ON c.id = ci.cart_id
+		WHERE c.user_id = $1
+	`, userID).Scan(&got)
+	assert.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+// productIDベースの在庫検証
+func assertProductStockByID(t *testing.T, productID int64, want int32) {
+	t.Helper()
+	var got int32
+	err := testDB.QueryRow(`
+		SELECT stock_quantity FROM products WHERE id = $1
+	`, productID).Scan(&got)
+	assert.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+// skuベースの在庫検証
+func assertProductStockBySKU(t *testing.T, sku string, want int32) {
+	t.Helper()
+	var got int32
+	err := testDB.QueryRow(`
+		SELECT stock_quantity FROM products WHERE sku = $1
+	`, sku).Scan(&got)
+	assert.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+// DBクリーンアップ
+func cleanupOrderRelatedTables(t *testing.T) {
+	t.Helper()
+	_, err := testDB.Exec(`
+		TRUNCATE TABLE order_items, orders, cart_items, carts, products, categories, users
+		RESTART IDENTITY CASCADE
+	`)
+	assert.NoError(t, err)
+}

--- a/doc/memo/2026/03/16_learning.md
+++ b/doc/memo/2026/03/16_learning.md
@@ -1,0 +1,30 @@
+# 2026-03-16 Learning Log
+
+## 今日の学習テーマ
+- Order integration test の SQL 検証処理をヘルパー化し、テストの可読性を上げる。
+- リファクタリング時のブランチ命名と、テストコメント粒度の基準を整理する。
+
+## 実施内容
+- ブランチ命名を `refactor/test-sql-assert-helpers` に決定。
+- `backend/tests/sql_assert_helper_test.go` に SQL アサートヘルパーを追加。
+  - `assertOrderCountByUser`
+  - `assertOrderItemCountByUser`
+  - `assertCartItemCountByUser`
+  - `assertProductStockByID`
+  - `assertProductStockBySKU`
+  - `cleanupOrderRelatedTables`
+- `backend/tests/order_integration_test.go` のインライン SQL 検証をヘルパー呼び出しへ段階的に置換。
+- 共有ヘルパーファイルに integration ビルドタグを付与し、通常テストとのビルド不整合リスクを回避。
+- `go test -tags=integration ./tests -run TestCreateOrderHandler* -v` でパス確認。
+
+## 学び・気づき
+- リファクタリング作業は Red -> Green を厳密適用しなくても、"1テストずつ置換" で安全に進められる。
+- テストコメントは「行単位の説明」より「仕様意図を1ブロックで説明」のほうが読みやすい。
+  - NG に近い: `assert` ごとの言い換えコメント
+  - 良い: 副作用や不変条件をまとめて説明するコメント
+- ブランチ命名は作業の性質に合わせるとレビューしやすい。
+  - 今回は `chore/*` より `refactor/*` が適切。
+
+## 次回に活かすメモ
+- テストヘルパー追加時は、対象テストファイルの build tag と揃えることを最初に確認する。
+- 置換後は affected scope のみを最小コマンドで再実行して確認する。

--- a/doc/task.md
+++ b/doc/task.md
@@ -499,19 +499,19 @@
       - 副作用: 在庫正確にデクリメント、合計金額計算
     - [x] テスト実行でサイクル確認（Red）
   - ステップ 3: プロダクトコード実装（`handler/order.go`）
-    - [ ] トランザクション開始
+    - [x] トランザクション開始
     - [x] 各商品を FOR UPDATE で取得＆ロック
-    - [ ] 在庫チェック → 不足時は 409 Conflict（ロールバック）
-    - [ ] デクリメント＆ orders, order_items 作成
-    - [ ] コミット後にレスポンス返却（201 Created）
-    - [ ] テスト全 PASS（Green）
+    - [x] 在庫チェック → 不足時は 409 Conflict（ロールバック）
+    - [x] デクリメント＆ orders, order_items 作成
+    - [x] コミット後にレスポンス返却（201 Created）
+    - [x] テスト全 PASS（Green）
   - ステップ 4: リファクタリング（Refactor）
-    - [ ] エラーハンドリング改善
-    - [ ] トランザクション処理の可読性向上
+    - [x] エラーハンドリング改善
+    - [x] トランザクション処理の可読性向上
   - 受け入れ条件:
-    - [ ] ユニットテスト全 PASS、カバレッジ > 80%
-    - [ ] 在庫がトランザクション内で正確にデクリメント
-    - [ ] 在庫不足時にロールバック・409 返却
+    - [x] ユニットテスト全 PASS、カバレッジ > 80%
+    - [x] 在庫がトランザクション内で正確にデクリメント
+    - [x] 在庫不足時にロールバック・409 返却
   - ファイル影響: `backend/handler/order.go` (新規), `backend/handler/order_test.go` (新規)
   - コミット例: `feat(handler): add CreateOrderHandler with TDD (tests + implementation)`
 


### PR DESCRIPTION
`CreateOrderHandler`で使用しているDB検証をヘルパー化
- 対象
  - asserOrderCountByUser
  - assertOrderItemCountByUser
  - assertCartItemCountByUser
  - assertProductStockByID
  - assertProductStockBySKU
  - cleanupOrderRelatedTables