### PR TITLE
fix(order) include product_name_snapshot in order items query #49

### DIFF
--- a/backend/auth/middleware_test.go
+++ b/backend/auth/middleware_test.go
@@ -179,8 +179,8 @@ func (f *FakeQuerier) GetProductForUpdate(ctx context.Context, id int64) (db.Pro
 	return db.Product{}, nil
 }
 
-func (f *FakeQuerier) ListOrderItemsByOrderID(ctx context.Context, orderID int64) ([]db.ListOrderItemsByOrderIDRow, error) {
-	return []db.ListOrderItemsByOrderIDRow{}, nil
+func (f *FakeQuerier) ListOrderItemsByOrderID(ctx context.Context, orderID int64) ([]db.OrderItem, error) {
+	return []db.OrderItem{}, nil
 }
 
 func (f *FakeQuerier) ListOrdersByUser(ctx context.Context, userID int64) ([]db.ListOrdersByUserRow, error) {

--- a/backend/db/querier.go
+++ b/backend/db/querier.go
@@ -37,7 +37,7 @@ type Querier interface {
 	ListCartItems(ctx context.Context, cartID int64) ([]ListCartItemsRow, error)
 	ListCartItemsByUser(ctx context.Context, userID int64) ([]ListCartItemsByUserRow, error)
 	ListCategories(ctx context.Context) ([]Category, error)
-	ListOrderItemsByOrderID(ctx context.Context, orderID int64) ([]ListOrderItemsByOrderIDRow, error)
+	ListOrderItemsByOrderID(ctx context.Context, orderID int64) ([]OrderItem, error)
 	ListOrdersByUser(ctx context.Context, userID int64) ([]ListOrdersByUserRow, error)
 	ListProducts(ctx context.Context) ([]Product, error)
 	RemoveCartItem(ctx context.Context, id int64) error

--- a/backend/db/query.sql.go
+++ b/backend/db/query.sql.go
@@ -742,37 +742,28 @@ func (q *Queries) ListCategories(ctx context.Context) ([]Category, error) {
 
 const listOrderItemsByOrderID = `-- name: ListOrderItemsByOrderID :many
 SELECT
-    id, order_id, product_id, quantity, unit_price, created_at, updated_at
+    id, order_id, product_id, quantity, unit_price, product_name_snapshot, created_at, updated_at
 FROM order_items
 WHERE order_id = $1
 ORDER BY id
 `
 
-type ListOrderItemsByOrderIDRow struct {
-	ID        int64     `json:"id"`
-	OrderID   int64     `json:"order_id"`
-	ProductID int64     `json:"product_id"`
-	Quantity  int32     `json:"quantity"`
-	UnitPrice int64     `json:"unit_price"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
-}
-
-func (q *Queries) ListOrderItemsByOrderID(ctx context.Context, orderID int64) ([]ListOrderItemsByOrderIDRow, error) {
+func (q *Queries) ListOrderItemsByOrderID(ctx context.Context, orderID int64) ([]OrderItem, error) {
 	rows, err := q.db.QueryContext(ctx, listOrderItemsByOrderID, orderID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []ListOrderItemsByOrderIDRow
+	var items []OrderItem
 	for rows.Next() {
-		var i ListOrderItemsByOrderIDRow
+		var i OrderItem
 		if err := rows.Scan(
 			&i.ID,
 			&i.OrderID,
 			&i.ProductID,
 			&i.Quantity,
 			&i.UnitPrice,
+			&i.ProductNameSnapshot,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {

--- a/backend/handler/order.go
+++ b/backend/handler/order.go
@@ -250,8 +250,8 @@ func CancelOrderHandler(conn *sql.DB, queries *db.Queries) gin.HandlerFunc {
 }
 
 type OrderWithItems struct {
-	Order db.ListOrdersByUserRow          `json:"order"`
-	Items []db.ListOrderItemsByOrderIDRow `json:"items"`
+	Order db.ListOrdersByUserRow `json:"order"`
+	Items []db.OrderItem         `json:"items"`
 }
 
 func getOrderLogic(ctx context.Context, qtx db.Querier, userID int64) ([]OrderWithItems, error) {

--- a/backend/handler/order_test.go
+++ b/backend/handler/order_test.go
@@ -528,7 +528,7 @@ func TestCancelOrderLogic(t *testing.T) {
 						ID: 1, UserID: 1, Total: 1500, Status: "pending", CreatedAt: now, UpdatedAt: now,
 					}, nil)
 				m.On("ListOrderItemsByOrderID", mock.Anything, int64(1)).Return(
-					[]db.ListOrderItemsByOrderIDRow{
+					[]db.OrderItem{
 						{
 							ID: 1, OrderID: 1, ProductID: 100, Quantity: 2, UnitPrice: 750, CreatedAt: now, UpdatedAt: now,
 						},
@@ -549,7 +549,7 @@ func TestCancelOrderLogic(t *testing.T) {
 				m.On("GetOrderByIDForUpdate", mock.Anything, int64(2)).Return(
 					db.GetOrderByIDForUpdateRow{ID: 2, UserID: 2, Total: 3000, Status: "pending", CreatedAt: now, UpdatedAt: now}, nil)
 				m.On("ListOrderItemsByOrderID", mock.Anything, int64(2)).Return(
-					[]db.ListOrderItemsByOrderIDRow{
+					[]db.OrderItem{
 						{ID: 1, OrderID: 2, ProductID: 101, Quantity: 1, UnitPrice: 1000, CreatedAt: now, UpdatedAt: now},
 						{ID: 2, OrderID: 2, ProductID: 102, Quantity: 2, UnitPrice: 1000, CreatedAt: now, UpdatedAt: now},
 					}, nil)
@@ -603,7 +603,7 @@ func TestCancelOrderLogic(t *testing.T) {
 				m.On("GetOrderByIDForUpdate", mock.Anything, int64(20)).Return(
 					db.GetOrderByIDForUpdateRow{ID: 20, UserID: 5, Total: 800, Status: "pending", CreatedAt: now, UpdatedAt: now}, nil)
 				m.On("ListOrderItemsByOrderID", mock.Anything, int64(20)).Return(
-					[]db.ListOrderItemsByOrderIDRow{
+					[]db.OrderItem{
 						{ID: 1, OrderID: 20, ProductID: 200, Quantity: 1, UnitPrice: 800, CreatedAt: now, UpdatedAt: now},
 					}, nil)
 				m.On("UpdateProductStock", mock.Anything, db.UpdateProductStockParams{ID: 200, StockQuantity: 1}).Return(
@@ -620,7 +620,7 @@ func TestCancelOrderLogic(t *testing.T) {
 				m.On("GetOrderByIDForUpdate", mock.Anything, int64(21)).Return(
 					db.GetOrderByIDForUpdateRow{ID: 21, UserID: 6, Total: 1200, Status: "pending", CreatedAt: now, UpdatedAt: now}, nil)
 				m.On("ListOrderItemsByOrderID", mock.Anything, int64(21)).Return(
-					[]db.ListOrderItemsByOrderIDRow{
+					[]db.OrderItem{
 						{ID: 1, OrderID: 21, ProductID: 201, Quantity: 1, UnitPrice: 1200, CreatedAt: now, UpdatedAt: now},
 					}, nil)
 				m.On("UpdateProductStock", mock.Anything, db.UpdateProductStockParams{ID: 201, StockQuantity: 1}).Return(
@@ -681,7 +681,7 @@ func TestGetOrderLogic(t *testing.T) {
 						},
 					}, nil)
 				m.On("ListOrderItemsByOrderID", mock.Anything, int64(1)).Return(
-					[]db.ListOrderItemsByOrderIDRow{
+					[]db.OrderItem{
 						{
 							ID:        1,
 							OrderID:   1,
@@ -736,7 +736,7 @@ func TestGetOrderLogic(t *testing.T) {
 						},
 					}, nil)
 				m.On("ListOrderItemsByOrderID", mock.Anything, int64(1)).Return(
-					[]db.ListOrderItemsByOrderIDRow{}, errors.New("db error"))
+					[]db.OrderItem{}, errors.New("db error"))
 			},
 		},
 	}
@@ -776,13 +776,14 @@ func TestGetOrdersHandler(t *testing.T) {
 	now := time.Now()
 
 	tests := []struct {
-		name           string
-		query          string
-		userID         any
-		setupMock      func(*testutil.MockDB)
-		expectedStatus int
-		expectedCount  int
-		expectedErrMsg string
+		name                        string
+		query                       string
+		userID                      any
+		setupMock                   func(*testutil.MockDB)
+		expectedStatus              int
+		expectedCount               int
+		expectedErrMsg              string
+		expectedProductNameSnapshot string
 	}{
 		{
 			name:           "U1: 注文確認成功 フィルタなし",
@@ -811,7 +812,7 @@ func TestGetOrdersHandler(t *testing.T) {
 						},
 					}, nil)
 				m.On("ListOrderItemsByOrderID", mock.Anything, int64(1)).Return(
-					[]db.ListOrderItemsByOrderIDRow{
+					[]db.OrderItem{
 						{
 							ID:        11,
 							OrderID:   1,
@@ -823,7 +824,7 @@ func TestGetOrdersHandler(t *testing.T) {
 						},
 					}, nil)
 				m.On("ListOrderItemsByOrderID", mock.Anything, int64(2)).Return(
-					[]db.ListOrderItemsByOrderIDRow{
+					[]db.OrderItem{
 						{
 							ID:        21,
 							OrderID:   2,
@@ -864,7 +865,7 @@ func TestGetOrdersHandler(t *testing.T) {
 					}, nil)
 
 				m.On("ListOrderItemsByOrderID", mock.Anything, int64(1)).Return(
-					[]db.ListOrderItemsByOrderIDRow{
+					[]db.OrderItem{
 						{
 							ID:        11,
 							OrderID:   1,
@@ -877,7 +878,7 @@ func TestGetOrdersHandler(t *testing.T) {
 					}, nil)
 
 				m.On("ListOrderItemsByOrderID", mock.Anything, int64(2)).Return(
-					[]db.ListOrderItemsByOrderIDRow{
+					[]db.OrderItem{
 						{
 							ID:        21,
 							OrderID:   2,
@@ -918,7 +919,7 @@ func TestGetOrdersHandler(t *testing.T) {
 					}, nil)
 
 				m.On("ListOrderItemsByOrderID", mock.Anything, int64(1)).Return(
-					[]db.ListOrderItemsByOrderIDRow{
+					[]db.OrderItem{
 						{
 							ID:        11,
 							OrderID:   1,
@@ -931,7 +932,7 @@ func TestGetOrdersHandler(t *testing.T) {
 					}, nil)
 
 				m.On("ListOrderItemsByOrderID", mock.Anything, int64(2)).Return(
-					[]db.ListOrderItemsByOrderIDRow{
+					[]db.OrderItem{
 						{
 							ID:        21,
 							OrderID:   2,
@@ -972,7 +973,7 @@ func TestGetOrdersHandler(t *testing.T) {
 					}, nil)
 
 				m.On("ListOrderItemsByOrderID", mock.Anything, int64(1)).Return(
-					[]db.ListOrderItemsByOrderIDRow{
+					[]db.OrderItem{
 						{
 							ID:        11,
 							OrderID:   1,
@@ -985,7 +986,7 @@ func TestGetOrdersHandler(t *testing.T) {
 					}, nil)
 
 				m.On("ListOrderItemsByOrderID", mock.Anything, int64(2)).Return(
-					[]db.ListOrderItemsByOrderIDRow{
+					[]db.OrderItem{
 						{
 							ID:        21,
 							OrderID:   2,
@@ -1042,7 +1043,7 @@ func TestGetOrdersHandler(t *testing.T) {
 						},
 					}, nil)
 				m.On("ListOrderItemsByOrderID", mock.Anything, int64(1)).Return(
-					[]db.ListOrderItemsByOrderIDRow{
+					[]db.OrderItem{
 						{
 							ID:        11,
 							OrderID:   1,
@@ -1054,7 +1055,7 @@ func TestGetOrdersHandler(t *testing.T) {
 						},
 					}, nil)
 				m.On("ListOrderItemsByOrderID", mock.Anything, int64(2)).Return(
-					[]db.ListOrderItemsByOrderIDRow{
+					[]db.OrderItem{
 						{
 							ID:        21,
 							OrderID:   2,
@@ -1094,7 +1095,7 @@ func TestGetOrdersHandler(t *testing.T) {
 						},
 					}, nil)
 				m.On("ListOrderItemsByOrderID", mock.Anything, int64(1)).Return(
-					[]db.ListOrderItemsByOrderIDRow{
+					[]db.OrderItem{
 						{
 							ID:        11,
 							OrderID:   1,
@@ -1106,7 +1107,7 @@ func TestGetOrdersHandler(t *testing.T) {
 						},
 					}, nil)
 				m.On("ListOrderItemsByOrderID", mock.Anything, int64(2)).Return(
-					[]db.ListOrderItemsByOrderIDRow{
+					[]db.OrderItem{
 						{
 							ID:        21,
 							OrderID:   2,
@@ -1126,6 +1127,39 @@ func TestGetOrdersHandler(t *testing.T) {
 			userID:         "not-a-number",
 			expectedErrMsg: "認証が必要です",
 			setupMock:      nil,
+		},
+		{
+			name:                        "U10: 明細にproduct_name_snapshotが含まれる",
+			expectedStatus:              http.StatusOK,
+			expectedCount:               1,
+			userID:                      int64(1),
+			expectedProductNameSnapshot: "House Blend",
+			setupMock: func(m *testutil.MockDB) {
+				m.On("ListOrdersByUser", mock.Anything, int64(1)).Return(
+					[]db.ListOrdersByUserRow{
+						{
+							ID:        1,
+							UserID:    1,
+							Total:     1500,
+							Status:    "pending",
+							CreatedAt: now,
+							UpdatedAt: now,
+						},
+					}, nil)
+				m.On("ListOrderItemsByOrderID", mock.Anything, int64(1)).Return(
+					[]db.OrderItem{
+						{
+							ID:                  11,
+							OrderID:             1,
+							ProductID:           100,
+							Quantity:            2,
+							UnitPrice:           750,
+							ProductNameSnapshot: "House Blend",
+							CreatedAt:           now,
+							UpdatedAt:           now,
+						},
+					}, nil)
+			},
 		},
 	}
 
@@ -1167,6 +1201,9 @@ func TestGetOrdersHandler(t *testing.T) {
 					for _, order := range body.Orders {
 						assert.Equal(t, "cancelled", order.Order.Status)
 					}
+				}
+				if tt.expectedProductNameSnapshot != "" && len(body.Orders) > 0 && len(body.Orders[0].Items) > 0 {
+					assert.Equal(t, tt.expectedProductNameSnapshot, body.Orders[0].Items[0].ProductNameSnapshot)
 				}
 			} else {
 				var body struct {

--- a/backend/handler/testutil/mockdb.go
+++ b/backend/handler/testutil/mockdb.go
@@ -164,12 +164,12 @@ func (m *MockDB) GetOrderByIDForUpdate(ctx context.Context, id int64) (db.GetOrd
 	return args.Get(0).(db.GetOrderByIDForUpdateRow), args.Error(1)
 }
 
-func (m *MockDB) ListOrderItemsByOrderID(ctx context.Context, orderID int64) ([]db.ListOrderItemsByOrderIDRow, error) {
+func (m *MockDB) ListOrderItemsByOrderID(ctx context.Context, orderID int64) ([]db.OrderItem, error) {
 	args := m.Called(ctx, orderID)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
-	return args.Get(0).([]db.ListOrderItemsByOrderIDRow), args.Error(1)
+	return args.Get(0).([]db.OrderItem), args.Error(1)
 }
 
 func (m *MockDB) UpdateOrderStatus(ctx context.Context, arg db.UpdateOrderStatusParams) (db.UpdateOrderStatusRow, error) {

--- a/backend/query.sql
+++ b/backend/query.sql
@@ -263,7 +263,7 @@ FOR UPDATE;
 
 -- name: ListOrderItemsByOrderID :many
 SELECT
-    id, order_id, product_id, quantity, unit_price, created_at, updated_at
+    id, order_id, product_id, quantity, unit_price, product_name_snapshot, created_at, updated_at
 FROM order_items
 WHERE order_id = $1
 ORDER BY id;


### PR DESCRIPTION
#49 の対応
- 注文履歴取得の明細取得クエリにproduct_name_snapshotを追加
- sqlc生成コードを更新
- 注文履歴レスポンスで商品名スナップショットを返却