### PR TITLE
Feat:リフレッシュトークン更新用エンドポイント

### DIFF
--- a/backend/handler/refresh.go
+++ b/backend/handler/refresh.go
@@ -1,0 +1,129 @@
+package handler
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"net/http"
+	"sol_coffeesys/backend/auth"
+	"sol_coffeesys/backend/db"
+	"sol_coffeesys/backend/pkg/respond"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func RefreshTokenHandler(q db.Querier, tokenGenerator auth.TokenGenerator) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		cookie, err := c.Request.Cookie("refresh_token")
+		if err != nil {
+			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			return
+		}
+		sum := sha256.Sum256([]byte(cookie.Value))
+		hash := hex.EncodeToString(sum[:])
+
+		rt, err := q.GetRefreshTokenByHash(c.Request.Context(), hash)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			} else {
+				respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+			}
+			c.Abort()
+			return
+		}
+
+		if rt.RevokedAt.Valid || rt.ExpiresAt.Before(time.Now()) {
+			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			c.Abort()
+			return
+		}
+
+		user, err := q.GetUserByID(c.Request.Context(), rt.UserID)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			} else {
+				respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+			}
+			c.Abort()
+			return
+		}
+
+		newRaw := make([]byte, 32)
+		if _, err := rand.Read(newRaw); err != nil {
+			respond.RespondError(c, http.StatusInternalServerError, "トークンの生成に失敗しました")
+			c.Abort()
+			return
+		}
+		newRefresh := hex.EncodeToString(newRaw)
+		newSum := sha256.Sum256([]byte(newRefresh))
+		newHash := hex.EncodeToString(newSum[:])
+
+		expiresAt := time.Now().Add(14 * 24 * time.Hour)
+
+		if _, err := q.CreateRefreshToken(c.Request.Context(), db.CreateRefreshTokenParams{
+			UserID:    user.ID,
+			TokenHash: newHash,
+			ExpiresAt: expiresAt,
+		}); err != nil {
+			respond.RespondError(c, http.StatusInternalServerError, "リフレッシュトークンの保存に失敗しました")
+			c.Abort()
+			return
+		}
+
+		if err := q.RevokeRefreshTokenByHash(c.Request.Context(), hash); err != nil {
+			respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+			c.Abort()
+			return
+		}
+
+		accessToken, err := tokenGenerator.GenerateToken(user.ID)
+		if err != nil {
+			respond.RespondError(c, http.StatusInternalServerError, "トークンの生成に失敗しました")
+			c.Abort()
+			return
+		}
+
+		accessCookie := &http.Cookie{
+			Name:     "access_token",
+			Value:    accessToken,
+			HttpOnly: true,
+			Path:     "/",
+			Expires:  time.Now().Add(15 * time.Minute),
+			MaxAge:   15 * 60,
+			SameSite: http.SameSiteLaxMode,
+		}
+		refreshCookie := &http.Cookie{
+			Name:     "refresh_token",
+			Value:    newRefresh,
+			HttpOnly: true,
+			Path:     "/api/refresh",
+			Expires:  expiresAt,
+			MaxAge:   14 * 24 * 60 * 60,
+			SameSite: http.SameSiteStrictMode,
+		}
+		if gin.Mode() == gin.ReleaseMode {
+			accessCookie.Secure = true
+			refreshCookie.Secure = true
+		}
+
+		http.SetCookie(c.Writer, accessCookie)
+		http.SetCookie(c.Writer, refreshCookie)
+
+		c.JSON(http.StatusOK, gin.H{
+			"message": "トークンを更新しました",
+			"token":   accessToken,
+			"user": gin.H{
+				"id":    user.ID,
+				"name":  user.Name,
+				"email": user.Email,
+				"role":  user.Role,
+			},
+		})
+
+	}
+}

--- a/backend/handler/refresh_test.go
+++ b/backend/handler/refresh_test.go
@@ -1,0 +1,254 @@
+package handler_test
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sol_coffeesys/backend/db"
+	"sol_coffeesys/backend/handler"
+	"sol_coffeesys/backend/handler/testutil"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockTokenGenerator struct {
+	mock.Mock
+}
+
+func (m *MockTokenGenerator) GenerateToken(userID int64) (string, error) {
+	args := m.Called(userID)
+	return args.String(0), args.Error(1)
+}
+
+func TestRefresTokenHandler_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.Default()
+	mockDB := new(testutil.MockDB)
+	mockTG := new(MockTokenGenerator)
+
+	oldRefresh := strings.Repeat("a", 64)
+	sum := sha256.Sum256([]byte(oldRefresh))
+	oldHash := hex.EncodeToString(sum[:])
+
+	mockDB.On("GetRefreshTokenByHash", mock.Anything, oldHash).Return(
+		db.RefreshToken{
+			ID:        1,
+			UserID:    1,
+			TokenHash: oldHash,
+			ExpiresAt: time.Now().Add(1 * time.Hour),
+		}, nil)
+
+	mockDB.On("GetUserByID", mock.Anything, int64(1)).Return(
+		db.User{
+			ID:    1,
+			Email: "test@example.com",
+			Name:  "Test",
+			Role:  "member",
+		}, nil)
+
+	mockTG.On("GenerateToken", int64(1)).Return("new_access_token", nil)
+
+	var captured db.CreateRefreshTokenParams
+	mockDB.On("CreateRefreshToken", mock.Anything, mock.Anything).Return(
+		func(arg mock.Arguments) {
+			captured = arg.Get(1).(db.CreateRefreshTokenParams)
+		}).Return(db.RefreshToken{ID: 2, UserID: 1}, nil)
+
+	mockDB.On("RevokeRefreshTokenByHash", mock.Anything, oldHash).Return(nil)
+
+	router.POST("/api/refresh", handler.RefreshTokenHandler(mockDB, mockTG))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/refresh", nil)
+	req.AddCookie(&http.Cookie{
+		Name:  "refresh_token",
+		Value: oldRefresh,
+		Path:  "/api/refresh",
+	})
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	resp := w.Result()
+	cookies := resp.Cookies()
+	var accessCookie, refreshCookie *http.Cookie
+	for _, c := range cookies {
+		if c.Name == "access_token" {
+			accessCookie = c
+		}
+		if c.Name == "refersh_token" {
+			refreshCookie = c
+		}
+	}
+
+	assert.NotNil(t, accessCookie)
+	assert.NotNil(t, refreshCookie)
+	assert.True(t, accessCookie.HttpOnly)
+	assert.Equal(t, "/", accessCookie.Path)
+	assert.Equal(t, 15*60, accessCookie.MaxAge)
+	assert.Equal(t, http.SameSiteLaxMode, accessCookie.SameSite)
+
+	assert.True(t, refreshCookie.HttpOnly)
+	assert.Equal(t, "/api/refresh", refreshCookie.Path)
+	assert.Equal(t, 14*24*60*60, refreshCookie.MaxAge)
+	assert.Equal(t, http.SameSiteStrictMode, refreshCookie.SameSite)
+	assert.Equal(t, 64, len(refreshCookie.Value))
+
+	sum2 := sha256.Sum256([]byte(refreshCookie.Value))
+	gotHash := hex.EncodeToString(sum2[:])
+	assert.Equal(t, gotHash, captured.TokenHash)
+	assert.WithinDuration(t, time.Now().Add(14*24*time.Hour), captured.ExpiresAt, 5*time.Second)
+
+	mockDB.AssertExpectations(t)
+	mockTG.AssertExpectations(t)
+
+}
+
+func TestRefreshTokenHandler_Errros(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name           string
+		setupMock      func(m *testutil.MockDB)
+		setupTG        func(tg *MockTokenGenerator)
+		cookie         string
+		expectedStatus int
+	}{
+		{
+			name:           "Cookie欠如",
+			setupMock:      nil,
+			cookie:         "",
+			expectedStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "token未登録",
+			setupMock: func(m *testutil.MockDB) {
+				oldRefresh := strings.Repeat("a", 64)
+				sum := sha256.Sum256([]byte(oldRefresh))
+				oldHash := hex.EncodeToString(sum[:])
+				m.On("GetRefreshTokenByHash", mock.Anything, oldHash).Return(
+					db.RefreshToken{}, sql.ErrNoRows)
+			},
+			cookie:         strings.Repeat("a", 64),
+			expectedStatus: http.StatusUnauthorized,
+		},
+		{
+			name:           "token期限切れ",
+			expectedStatus: http.StatusUnauthorized,
+			setupMock: func(m *testutil.MockDB) {
+				oldRefresh := strings.Repeat("a", 64)
+				sum := sha256.Sum256([]byte(oldRefresh))
+				oldHash := hex.EncodeToString(sum[:])
+				m.On("GetRefreshTokenByHash", mock.Anything, oldHash).Return(
+					db.RefreshToken{
+						ID:        1,
+						UserID:    1,
+						TokenHash: oldHash,
+						ExpiresAt: time.Now().Add(-1 * time.Hour),
+					}, nil)
+			},
+			cookie: strings.Repeat("a", 64),
+		},
+		{
+			name:           "token失効済み",
+			expectedStatus: http.StatusUnauthorized,
+			setupMock: func(m *testutil.MockDB) {
+				oldRefresh := strings.Repeat("a", 64)
+				sum := sha256.Sum256([]byte(oldRefresh))
+				oldHash := hex.EncodeToString(sum[:])
+				m.On("GetRefreshTokenByHash", mock.Anything, oldHash).Return(db.RefreshToken{
+					ID:        1,
+					UserID:    1,
+					TokenHash: oldHash,
+					ExpiresAt: time.Now().Add(1 * time.Hour),
+					RevokedAt: sql.NullTime{Valid: true, Time: time.Now().Add(-1 * time.Hour)},
+				}, nil)
+			},
+			cookie: strings.Repeat("a", 64),
+		},
+		{
+			name:           "DBエラー Get",
+			expectedStatus: http.StatusInternalServerError,
+			setupMock: func(m *testutil.MockDB) {
+				oldRefresh := strings.Repeat("a", 64)
+				sum := sha256.Sum256([]byte(oldRefresh))
+				oldHash := hex.EncodeToString(sum[:])
+				m.On("GetRefreshTokenByHash", mock.Anything, oldHash).Return(db.RefreshToken{}, errors.New("db error"))
+			},
+			cookie: strings.Repeat("a", 64),
+		},
+		{
+			name:           "DBエラー Create",
+			expectedStatus: http.StatusInternalServerError,
+		},
+		{
+			name:           "DBエラー Revoke",
+			expectedStatus: http.StatusInternalServerError,
+		},
+		{
+			name:           "token生成失敗",
+			expectedStatus: http.StatusInternalServerError,
+			setupMock: func(m *testutil.MockDB) {
+				oldRefresh := strings.Repeat("a", 64)
+				sum := sha256.Sum256([]byte(oldRefresh))
+				oldHash := hex.EncodeToString(sum[:])
+				m.On("GetRefreshTokenByHash", mock.Anything, oldHash).Return(
+					db.RefreshToken{
+						ID:        1,
+						UserID:    1,
+						TokenHash: oldHash,
+						ExpiresAt: time.Now().Add(1 * time.Hour),
+					}, nil)
+				m.On("GetUserByID", mock.Anything, int64(1)).Return(db.User{ID: 1, Email: "x", Name: "x", Role: "member"}, nil)
+			},
+			setupTG: func(tg *MockTokenGenerator) {
+				tg.On("GenerateToken", int64(1)).Return("", errors.New("token gen failed"))
+			},
+			cookie: strings.Repeat("a", 64),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := gin.Default()
+			mockDB := new(testutil.MockDB)
+			mockTG := new(MockTokenGenerator)
+
+			if tt.setupMock != nil {
+				tt.setupMock(mockDB)
+			}
+			if tt.setupTG != nil {
+				tt.setupTG(mockTG)
+			} else {
+				mockTG.On("GenerateToken", mock.Anything).Return("ignored", nil)
+			}
+
+			router.POST("/api/refresh", handler.RefreshTokenHandler(mockDB, mockTG))
+
+			req := httptest.NewRequest(http.MethodPost, "/api/refresh", nil)
+			if tt.cookie != "" {
+				req.AddCookie(&http.Cookie{
+					Name:  "refresh_token",
+					Value: tt.cookie,
+					Path:  "/api/refresh",
+				})
+			}
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			mockDB.AssertExpectations(t)
+			mockTG.AssertExpectations(t)
+		})
+	}
+}

--- a/backend/handler/refresh_test.go
+++ b/backend/handler/refresh_test.go
@@ -19,16 +19,7 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-type MockTokenGenerator struct {
-	mock.Mock
-}
-
-func (m *MockTokenGenerator) GenerateToken(userID int64) (string, error) {
-	args := m.Called(userID)
-	return args.String(0), args.Error(1)
-}
-
-func TestRefresTokenHandler_Success(t *testing.T) {
+func TestRefreshTokenHandler_Success(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	router := gin.Default()
@@ -58,10 +49,11 @@ func TestRefresTokenHandler_Success(t *testing.T) {
 	mockTG.On("GenerateToken", int64(1)).Return("new_access_token", nil)
 
 	var captured db.CreateRefreshTokenParams
-	mockDB.On("CreateRefreshToken", mock.Anything, mock.Anything).Return(
-		func(arg mock.Arguments) {
-			captured = arg.Get(1).(db.CreateRefreshTokenParams)
-		}).Return(db.RefreshToken{ID: 2, UserID: 1}, nil)
+	mockDB.On("CreateRefreshToken", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			captured = args.Get(1).(db.CreateRefreshTokenParams)
+		}).
+		Return(db.RefreshToken{ID: 2, UserID: 1}, nil)
 
 	mockDB.On("RevokeRefreshTokenByHash", mock.Anything, oldHash).Return(nil)
 
@@ -86,7 +78,7 @@ func TestRefresTokenHandler_Success(t *testing.T) {
 		if c.Name == "access_token" {
 			accessCookie = c
 		}
-		if c.Name == "refersh_token" {
+		if c.Name == "refresh_token" {
 			refreshCookie = c
 		}
 	}
@@ -188,11 +180,37 @@ func TestRefreshTokenHandler_Errros(t *testing.T) {
 			cookie: strings.Repeat("a", 64),
 		},
 		{
-			name:           "DBエラー Create",
+			name: "DBエラー Create",
+			setupMock: func(m *testutil.MockDB) {
+				oldRefersh := strings.Repeat("a", 64)
+				sum := sha256.Sum256([]byte(oldRefersh))
+				oldHash := hex.EncodeToString(sum[:])
+				m.On("GetRefreshTokenByHash", mock.Anything, oldHash).Return(
+					db.RefreshToken{ID: 1, UserID: 1, TokenHash: oldHash, ExpiresAt: time.Now().Add(1 * time.Hour)}, nil)
+				m.On("GetUserByID", mock.Anything, int64(1)).Return(
+					db.User{ID: 1, Email: "test@eample.com", Name: "test", Role: "member"}, nil)
+				m.On("CreateRefreshToken", mock.Anything, mock.Anything).Return(
+					db.RefreshToken{}, errors.New("db create error"))
+			},
+			cookie:         strings.Repeat("a", 64),
 			expectedStatus: http.StatusInternalServerError,
 		},
 		{
-			name:           "DBエラー Revoke",
+			name: "DBエラー Revoke",
+			setupMock: func(m *testutil.MockDB) {
+				oldRefersh := strings.Repeat("a", 64)
+				sum := sha256.Sum256([]byte(oldRefersh))
+				oldHash := hex.EncodeToString(sum[:])
+				m.On("GetRefreshTokenByHash", mock.Anything, oldHash).Return(
+					db.RefreshToken{ID: 1, UserID: 1, TokenHash: oldHash, ExpiresAt: time.Now().Add(1 * time.Hour)}, nil)
+				m.On("GetUserByID", mock.Anything, int64(1)).Return(
+					db.User{ID: 1, Email: "test@eample.com", Name: "test", Role: "member"}, nil)
+				m.On("CreateRefreshToken", mock.Anything, mock.Anything).Return(
+					db.RefreshToken{ID: 2, UserID: 1}, nil)
+				m.On("RevokeRefreshTokenByHash", mock.Anything, oldHash).Return(
+					errors.New("db revoke error"))
+			},
+			cookie:         strings.Repeat("a", 64),
 			expectedStatus: http.StatusInternalServerError,
 		},
 		{
@@ -210,7 +228,11 @@ func TestRefreshTokenHandler_Errros(t *testing.T) {
 						ExpiresAt: time.Now().Add(1 * time.Hour),
 					}, nil)
 				m.On("GetUserByID", mock.Anything, int64(1)).Return(db.User{ID: 1, Email: "x", Name: "x", Role: "member"}, nil)
+				m.On("CreateRefreshToken", mock.Anything, mock.Anything).Return(
+					db.RefreshToken{ID: 2, UserID: 1}, nil)
+				m.On("RevokeRefreshTokenByHash", mock.Anything, oldHash).Return(nil)
 			},
+
 			setupTG: func(tg *MockTokenGenerator) {
 				tg.On("GenerateToken", int64(1)).Return("", errors.New("token gen failed"))
 			},
@@ -229,8 +251,6 @@ func TestRefreshTokenHandler_Errros(t *testing.T) {
 			}
 			if tt.setupTG != nil {
 				tt.setupTG(mockTG)
-			} else {
-				mockTG.On("GenerateToken", mock.Anything).Return("ignored", nil)
 			}
 
 			router.POST("/api/refresh", handler.RefreshTokenHandler(mockDB, mockTG))

--- a/backend/handler/testutil/mockdb.go
+++ b/backend/handler/testutil/mockdb.go
@@ -192,3 +192,16 @@ func (m *MockDB) CreateRefreshToken(ctx context.Context, arg db.CreateRefreshTok
 	}
 	return args.Get(0).(db.RefreshToken), args.Error(1)
 }
+
+func (m *MockDB) GetRefreshTokenByHash(ctx context.Context, tokenHash string) (db.RefreshToken, error) {
+	args := m.Called(ctx, tokenHash)
+	if args.Get(0) == nil {
+		return db.RefreshToken{}, args.Error(1)
+	}
+	return args.Get(0).(db.RefreshToken), args.Error(1)
+}
+
+func (m *MockDB) RevokeRefreshTokenByHash(ctx context.Context, tokenHash string) error {
+	args := m.Called(ctx, tokenHash)
+	return args.Error(0)
+}

--- a/doc/memo/2026/04/06_learning.md
+++ b/doc/memo/2026/04/06_learning.md
@@ -1,0 +1,39 @@
+# 学習記録 2026-04-06
+
+## セッション 1 (20:16)
+
+### 取り組んだタスク
+- `/api/refresh` の TDD 実装（テスト → 実装のサイクル）を実施。
+- 正常系: リフレッシュ時のローテーション（新 refresh 発行、DB 保存、旧 token revoke、access + refresh Cookie 更新）を個別テストで実装。
+- 異常系: Cookie 欠如／トークン未登録／期限切れ／撤回済み／DB エラー／トークン生成エラー等をテーブル駆動テストで実装。
+- `testutil.MockDB` に `GetRefreshTokenByHash` と `RevokeRefreshTokenByHash` を追加。
+- `backend/handler/refresh.go` を実装（DB に新 refresh を保存して旧トークンを無効化、アクセス Cookie と refresh Cookie をセット）。
+- テストの修正: タイポ（refersh→refresh）、`CreateRefreshToken` の mock キャプチャは `Run(...).Return(...)` に修正、その他 mock 期待の追加。
+- Git commit を実施（ユーザーが「コミットは完了した」と報告）。
+
+### ユーザーが質問した内容
+- テーブル駆動テストにするかどうか（正常系は個別／異常系はテーブル駆動のハイブリッドを推奨）。
+- テスト実行時に起きた mock の重複・未設定エラーの解決方法。
+
+### 躓いたポイントと解決策
+- モック未設定による panic（assert: mock: I don't know what to return） → 各テストケースで必要なモック期待を明確化・追加。
+- `CreateRefreshToken` の引数キャプチャを `Run` で行う必要あり（誤って `Return(func...)` としていた箇所を修正）。
+- Cookie 名のタイプミス（`refersh_token`）を修正。
+- 実装とテストの呼び順不一致: もともと `GenerateToken` を先に呼んでおり、DB エラー系テストでモック期待が満たされず失敗 → 実装を `CreateRefreshToken` → `RevokeRefreshTokenByHash` → `GenerateToken` の順に変更して整合させた。
+- テスト実行で発生した個別の失敗を順に修正し、最終的に `go test ./backend/handler -run TestRefreshToken* -v` が PASS となった。
+
+### 次回課題
+1. `/api/logout` のテスト作成（Red）とハンドラ実装（Green）。
+2. CSRF 対策（double-submit cookie 等）の設計とミドルウェア + テスト追加（次フェーズ）。
+3. 既存の認証ミドルウェアを Cookie と Bearer の両対応にするテスト。
+
+### 変更ファイル一覧
+- backend/handler/refresh.go (新規実装/更新)
+- backend/handler/refresh_test.go (テスト追加/修正)
+- backend/handler/testutil/mockdb.go (モック追加)
+- backend/auth/jwt.go (exp 修正、既往作業として記録)
+- backend/handler/user.go (Login で refresh 生成済みの変更)
+
+### 実行コマンド実績
+- `gofmt -w backend/handler/refresh.go backend/handler/refresh_test.go backend/handler/testutil/mockdb.go`
+- `go test ./backend/handler -run TestRefreshToken* -v` → 全テスト PASS


### PR DESCRIPTION
### 概要
- `POST /api/refresh`はクライアントの`refresh_token`を受け取り検証して新しいアクセストークンとリフレッシュトークンを発行する

### 実装フロー
1. Cookie取得
2. SHA256ハッシュ化
3. `GetRefreshTokenByHash`で検証
4. `GetUserByID`
5. 新しいリフレッシュトークンを生成しDB保存
6. 急トークンをrevoke
7. アクセストークンを生成
8. アクセストークンとリフレッシュトークンをHttpOnly Cookieにセット
