### PR TITLE
Refactor: エラーレスポンス用関数のリファクタリング

### DIFF
--- a/backend/auth/middleware.go
+++ b/backend/auth/middleware.go
@@ -3,11 +3,11 @@ package auth
 import (
 	"database/sql"
 	"errors"
-	"net/http"
 	"strconv"
 	"strings"
 
 	"sol_coffeesys/backend/db"
+	"sol_coffeesys/backend/pkg/apperror"
 	"sol_coffeesys/backend/pkg/respond"
 
 	"github.com/gin-gonic/gin"
@@ -18,27 +18,27 @@ func AdminOnly(queries db.Querier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		tokenStr, err := tokenFromRequest(c)
 		if err != nil {
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			c.Abort()
 			return
 		}
 		token, err := Validate(tokenStr)
 		if err != nil || token == nil || !token.Valid {
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			c.Abort()
 			return
 		}
 
 		claims, ok := token.Claims.(jwt.MapClaims)
 		if !ok {
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			c.Abort()
 			return
 		}
 
 		rawID, ok := claims["user.id"]
 		if !ok {
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			c.Abort()
 			return
 		}
@@ -50,7 +50,7 @@ func AdminOnly(queries db.Querier) gin.HandlerFunc {
 		case string:
 			id, perr := strconv.ParseInt(v, 10, 64)
 			if perr != nil {
-				respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+				respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 				c.Abort()
 				return
 			}
@@ -60,17 +60,17 @@ func AdminOnly(queries db.Querier) gin.HandlerFunc {
 		user, err := queries.GetUserForUpdate(c.Request.Context(), userID)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+				respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 				c.Abort()
 				return
 			}
-			respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+			respond.RespondWithError(c, apperror.NewInternalError("GetUserForUpdate", err, apperror.InternalServerMessageCommon))
 			c.Abort()
 			return
 		}
 
 		if user.Role != "admin" {
-			respond.RespondError(c, http.StatusForbidden, "管理者権限が必要です")
+			respond.RespondWithError(c, apperror.NewForbiddenError("admin", "user", apperror.ForbiddenMessageAdmin))
 			c.Abort()
 			return
 		}
@@ -85,28 +85,28 @@ func RequireAuth(queries db.Querier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		tokenStr, err := tokenFromRequest(c)
 		if err != nil {
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			c.Abort()
 			return
 		}
 
 		token, err := Validate(tokenStr)
 		if err != nil || token == nil || !token.Valid {
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			c.Abort()
 			return
 		}
 
 		claims, ok := token.Claims.(jwt.MapClaims)
 		if !ok {
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			c.Abort()
 			return
 		}
 
 		rawID, ok := claims["user.id"]
 		if !ok {
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			c.Abort()
 			return
 		}
@@ -124,13 +124,13 @@ func RequireAuth(queries db.Querier) gin.HandlerFunc {
 		case string:
 			id, perr := strconv.ParseInt(v, 10, 64)
 			if perr != nil {
-				respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+				respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 				c.Abort()
 				return
 			}
 			userID = id
 		default:
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			c.Abort()
 			return
 		}
@@ -138,11 +138,11 @@ func RequireAuth(queries db.Querier) gin.HandlerFunc {
 		user, err := queries.GetUserForUpdate(c.Request.Context(), userID)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+				respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 				c.Abort()
 				return
 			}
-			respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+			respond.RespondWithError(c, apperror.NewInternalError("GetUserForUpdate", err, apperror.InternalServerMessageCommon))
 			c.Abort()
 			return
 		}

--- a/backend/handler/cart.go
+++ b/backend/handler/cart.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"net/http"
 	"sol_coffeesys/backend/db"
+	"sol_coffeesys/backend/pkg/apperror"
 	"sol_coffeesys/backend/pkg/respond"
 	"strconv"
 	"time"
@@ -15,7 +16,7 @@ func GetCartHandler(q db.Querier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		raw, exists := c.Get("userID")
 		if !exists {
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
@@ -28,13 +29,13 @@ func GetCartHandler(q db.Querier) gin.HandlerFunc {
 		case float64:
 			userID = int64(v)
 		default:
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
 		rows, err := q.ListCartItemsByUser(c.Request.Context(), userID)
 		if err != nil {
-			respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+			respond.RespondWithError(c, apperror.NewInternalError("ListCartItemsByUser", err, apperror.InternalServerMessageCommon))
 			return
 		}
 
@@ -66,17 +67,17 @@ func AddToCartHandler(q db.Querier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		uid, ok := c.Get("userID")
 		if !ok {
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
 		var req addToCartRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
-			respond.RespondError(c, http.StatusBadRequest, "リクエスト形式が正しくありません")
+			respond.RespondWithError(c, apperror.NewValidationError("request", nil, "", ""))
 			return
 		}
 		if req.Quantity <= 0 {
-			respond.RespondError(c, http.StatusBadRequest, "quantityは1以上である必要があります")
+			respond.RespondWithError(c, apperror.NewValidationError("qty", req.Quantity, "", ""))
 			return
 		}
 
@@ -89,23 +90,23 @@ func AddToCartHandler(q db.Querier) gin.HandlerFunc {
 		case float64:
 			userID = int64(v)
 		default:
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
 		product, err := q.GetProduct(c.Request.Context(), req.ProductID)
 		if err != nil {
 			if err == sql.ErrNoRows {
-				respond.RespondError(c, http.StatusNotFound, "商品が見つかりません")
+				respond.RespondWithError(c, apperror.NewNotFoundError("product", req.ProductID, ""))
 			} else {
-				respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+				respond.RespondWithError(c, apperror.NewInternalError("GetProduct", err, apperror.InternalServerMessageCommon))
 			}
 			return
 		}
 
 		cart, err := q.GetOrCreateCartForUser(c.Request.Context(), userID)
 		if err != nil {
-			respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+			respond.RespondWithError(c, apperror.NewInternalError("GetOrCreateCartForUser", err, apperror.InternalServerMessageCommon))
 			return
 		}
 
@@ -116,7 +117,7 @@ func AddToCartHandler(q db.Querier) gin.HandlerFunc {
 			Price:     int64(product.Price),
 		})
 		if err != nil {
-			respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+			respond.RespondWithError(c, apperror.NewInternalError("AddCartItem", err, apperror.InternalServerMessageCommon))
 			return
 		}
 
@@ -133,23 +134,23 @@ func UpdateCartItemHandler(q db.Querier) gin.HandlerFunc {
 		// URL pramの解析
 		id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 		if err != nil {
-			respond.RespondError(c, http.StatusBadRequest, "idが正しくありません")
+			respond.RespondWithError(c, apperror.NewValidationError("id", id, "", ""))
 			return
 		}
 
 		uid, ok := c.Get("userID")
 		if !ok {
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 		var req updateCartItemRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
-			respond.RespondError(c, http.StatusBadRequest, "リクエスト形式が正しくありません")
+			respond.RespondWithError(c, apperror.NewValidationError("request", nil, "", ""))
 			return
 		}
 
 		if req.Quantity <= 0 {
-			respond.RespondError(c, http.StatusBadRequest, "quantitiyは１以上である必要があります")
+			respond.RespondWithError(c, apperror.NewValidationError("qty", req.Quantity, "", ""))
 			return
 		}
 
@@ -162,7 +163,7 @@ func UpdateCartItemHandler(q db.Querier) gin.HandlerFunc {
 		case float64:
 			userID = int64(v)
 		default:
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
@@ -173,9 +174,9 @@ func UpdateCartItemHandler(q db.Querier) gin.HandlerFunc {
 		})
 		if err != nil {
 			if err == sql.ErrNoRows {
-				respond.RespondError(c, http.StatusNotFound, "カートアイテムが見つかりません")
+				respond.RespondWithError(c, apperror.NewNotFoundError("cart_item", id, ""))
 			} else {
-				respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+				respond.RespondWithError(c, apperror.NewInternalError("UpdateCartItemQtyByUser", err, apperror.InternalServerMessageCommon))
 			}
 			return
 		}
@@ -189,13 +190,13 @@ func RemoveCartItemHandler(q db.Querier) gin.HandlerFunc {
 
 		id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 		if err != nil {
-			respond.RespondError(c, http.StatusBadRequest, "idが正しくありません")
+			respond.RespondWithError(c, apperror.NewValidationError("id", id, "", ""))
 			return
 		}
 
 		uid, ok := c.Get("userID")
 		if !ok {
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 		var userID int64
@@ -207,16 +208,16 @@ func RemoveCartItemHandler(q db.Querier) gin.HandlerFunc {
 		case float64:
 			userID = int64(v)
 		default:
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
 		item, err := q.GetCartItemByID(c.Request.Context(), id)
 		if err != nil {
 			if err == sql.ErrNoRows {
-				respond.RespondError(c, http.StatusNotFound, "カートアイテムが見つかりません")
+				respond.RespondWithError(c, apperror.NewNotFoundError("cart_item", id, ""))
 			} else {
-				respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+				respond.RespondWithError(c, apperror.NewInternalError("GetCartItemByID", err, apperror.InternalServerMessageCommon))
 			}
 			return
 		}
@@ -224,15 +225,15 @@ func RemoveCartItemHandler(q db.Querier) gin.HandlerFunc {
 		cart, err := q.GetCartByUser(c.Request.Context(), userID)
 		if err != nil {
 			if err == sql.ErrNoRows {
-				respond.RespondError(c, http.StatusNotFound, "カートが見つかりません")
+				respond.RespondWithError(c, apperror.NewNotFoundError("cart", userID, ""))
 			} else {
-				respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+				respond.RespondWithError(c, apperror.NewInternalError("GetCartByUser", err, apperror.InternalServerMessageCommon))
 			}
 			return
 		}
 
 		if item.CartID != cart.ID {
-			respond.RespondError(c, http.StatusNotFound, "カートアイテムが見つかりません")
+			respond.RespondWithError(c, apperror.NewNotFoundError("cart_item", id, ""))
 			return
 		}
 
@@ -240,7 +241,7 @@ func RemoveCartItemHandler(q db.Querier) gin.HandlerFunc {
 			ID:     id,
 			UserID: userID,
 		}); err != nil {
-			respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+			respond.RespondWithError(c, apperror.NewInternalError("RemoveCartItemByUser", err, apperror.InternalServerMessageCommon))
 			return
 		}
 
@@ -253,7 +254,7 @@ func ClearCartHandler(q db.Querier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		uid, ok := c.Get("userID")
 		if !ok {
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 		var userID int64
@@ -265,12 +266,12 @@ func ClearCartHandler(q db.Querier) gin.HandlerFunc {
 		case float64:
 			userID = int64(v)
 		default:
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
 		if err := q.ClearCartByUser(c.Request.Context(), userID); err != nil {
-			respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+			respond.RespondWithError(c, apperror.NewInternalError("ClearCartByUser", err, apperror.InternalServerMessageCommon))
 			return
 		}
 

--- a/backend/handler/category.go
+++ b/backend/handler/category.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"net/http"
 	"sol_coffeesys/backend/db"
+	"sol_coffeesys/backend/pkg/apperror"
 	"sol_coffeesys/backend/pkg/respond"
 	"strconv"
 
@@ -27,12 +28,12 @@ func CreateCategoryHandler(queries db.Querier) gin.HandlerFunc {
 		var req CreateCategoryHandlerRequest
 
 		if err := c.ShouldBindJSON(&req); err != nil {
-			respond.RespondError(c, http.StatusBadRequest, "リクエスト形式が正しくありません")
+			respond.RespondWithError(c, apperror.NewValidationError("request", nil, "", ""))
 			return
 		}
 
 		if req.Name == "" {
-			respond.RespondError(c, http.StatusBadRequest, "カテゴリ名は必須です")
+			respond.RespondWithError(c, apperror.NewValidationError("category", nil, "", ""))
 			return
 		}
 
@@ -49,7 +50,7 @@ func CreateCategoryHandler(queries db.Querier) gin.HandlerFunc {
 			Description: description,
 		})
 		if err != nil {
-			respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+			respond.RespondWithError(c, apperror.NewInternalError("CreateCategory", err, apperror.InternalServerMessageCommon))
 			return
 		}
 
@@ -77,18 +78,18 @@ func UpdateCategoryHandler(queries db.Querier) gin.HandlerFunc {
 
 		id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 		if err != nil {
-			respond.RespondError(c, http.StatusBadRequest, "IDが正しくありません")
+			respond.RespondWithError(c, apperror.NewValidationError("id", id, "", ""))
 			return
 		}
 
 		var req UpdateCategoryHandlerRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
-			respond.RespondError(c, http.StatusBadRequest, "リクエスト形式が正しくありません")
+			respond.RespondWithError(c, apperror.NewValidationError("request", nil, "", ""))
 			return
 		}
 
 		if req.Name == nil || *req.Name == "" {
-			respond.RespondError(c, http.StatusBadRequest, "カテゴリ名は必須です")
+			respond.RespondWithError(c, apperror.NewValidationError("category", nil, "", ""))
 			return
 		}
 
@@ -107,9 +108,9 @@ func UpdateCategoryHandler(queries db.Querier) gin.HandlerFunc {
 		})
 		if err != nil {
 			if err == sql.ErrNoRows {
-				respond.RespondError(c, http.StatusNotFound, "カテゴリが見つかりません")
+				respond.RespondWithError(c, apperror.NewNotFoundError("category", id, ""))
 			} else {
-				respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+				respond.RespondWithError(c, apperror.NewInternalError("UpdateCategory", err, apperror.InternalServerMessageCommon))
 			}
 			return
 		}
@@ -132,7 +133,7 @@ func GetCategoriesHandler(queries db.Querier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		categories, err := queries.ListCategories(c.Request.Context())
 		if err != nil {
-			respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+			respond.RespondWithError(c, apperror.NewInternalError("ListCategories", err, apperror.InternalServerMessageCommon))
 			return
 		}
 		resp := make([]CategoryResponse, 0, len(categories))
@@ -156,16 +157,16 @@ func DeleteCategoryHandler(queries db.Querier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 		if err != nil {
-			respond.RespondError(c, http.StatusBadRequest, "IDが正しくありません")
+			respond.RespondWithError(c, apperror.NewValidationError("id", id, "", ""))
 			return
 		}
 
 		respErr := queries.DeleteCategory(c.Request.Context(), int64(id))
 		if respErr != nil {
 			if respErr == sql.ErrNoRows {
-				respond.RespondError(c, http.StatusNotFound, "カテゴリが見つかりません")
+				respond.RespondWithError(c, apperror.NewNotFoundError("category", id, ""))
 			} else {
-				respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+				respond.RespondWithError(c, apperror.NewInternalError("DeleteCategory", respErr, apperror.InternalServerMessageCommon))
 			}
 			return
 		}

--- a/backend/handler/logout.go
+++ b/backend/handler/logout.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 	"sol_coffeesys/backend/db"
+	"sol_coffeesys/backend/pkg/apperror"
 	"sol_coffeesys/backend/pkg/respond"
 
 	"github.com/gin-gonic/gin"
@@ -50,7 +51,7 @@ func LogoutHandler(queries db.Querier) gin.HandlerFunc {
 			if errors.Is(err, sql.ErrNoRows) {
 
 			} else {
-				respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+				respond.RespondWithError(c, apperror.NewInternalError("RevokeRefreshTokenByHash", err, apperror.InternalServerMessageCommon))
 				c.Abort()
 				return
 			}

--- a/backend/handler/me.go
+++ b/backend/handler/me.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"sol_coffeesys/backend/auth"
 	"sol_coffeesys/backend/db"
+	"sol_coffeesys/backend/pkg/apperror"
 	"sol_coffeesys/backend/pkg/respond"
 	"strconv"
 	"strings"
@@ -17,31 +18,31 @@ func MeHandler(q db.Querier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		authHeader := c.GetHeader("Authorization")
 		if authHeader == "" {
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("token_not_found", apperror.UnauthorizedMessageAuth))
 			return
 		}
 		parts := strings.SplitN(authHeader, " ", 2)
 		if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("invalid_format_token", apperror.UnauthorizedMessageAuth))
 			return
 		}
 		tokenStr := parts[1]
 
 		token, err := auth.Validate(tokenStr)
 		if err != nil || token == nil || !token.Valid {
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("invalid_token", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
 		claims, ok := token.Claims.(jwt.MapClaims)
 		if !ok {
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("failed_to_decode_token", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
 		rawID, ok := claims["user.id"]
 		if !ok {
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("userID_claims_not_found", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
@@ -52,21 +53,21 @@ func MeHandler(q db.Querier) gin.HandlerFunc {
 		case string:
 			id, perr := strconv.ParseInt(v, 10, 64)
 			if perr != nil {
-				respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+				respond.RespondWithError(c, apperror.NewUnauthorizedError("userID_parse_failed", apperror.UnauthorizedMessageAuth))
 				return
 			}
 			userID = id
 		default:
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("userID_type_is_invalid", apperror.UnauthorizedMessageAuth))
 			return
 		}
 		user, err := q.GetUserForUpdate(c.Request.Context(), userID)
 		if err != nil {
 			if err == sql.ErrNoRows {
-				respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+				respond.RespondWithError(c, apperror.NewUnauthorizedError("userID_is_not_authenticated", apperror.UnauthorizedMessageAuth))
 				return
 			}
-			respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+			respond.RespondWithError(c, apperror.NewInternalError("GetUserForUpdate", err, apperror.InternalServerMessageCommon))
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{

--- a/backend/handler/order.go
+++ b/backend/handler/order.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"net/http"
 	"sol_coffeesys/backend/db"
+	"sol_coffeesys/backend/pkg/apperror"
 	"sol_coffeesys/backend/pkg/respond"
 	"strconv"
 
@@ -27,7 +29,7 @@ func createOrderLogic(ctx context.Context, qtx db.Querier, userID int64) (*db.Cr
 
 	// カートが空の場合はエラー
 	if len(items) == 0 {
-		return nil, errors.New("カートが空です")
+		return nil, apperror.NewValidationError("cart", nil, "", "")
 	}
 
 	// 合計金額計算
@@ -42,13 +44,13 @@ func createOrderLogic(ctx context.Context, qtx db.Querier, userID int64) (*db.Cr
 		product, err := qtx.GetProductForUpdate(ctx, item.ProductID)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				return nil, errors.New("商品が見つかりません")
+				return nil, apperror.NewNotFoundError("product", item.ProductID, apperror.NotFoundMessageProduct)
 			}
 			return nil, err
 		}
 
 		if product.StockQuantity < item.Quantity {
-			return nil, errors.New("在庫不足です")
+			return nil, apperror.NewConflictError("qty", fmt.Sprint(item.ProductID), "")
 		}
 	}
 
@@ -96,7 +98,7 @@ func CreateOrderHandler(conn *sql.DB, queries *db.Queries) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		raw, exists := c.Get("userID")
 		if !exists {
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
@@ -109,13 +111,13 @@ func CreateOrderHandler(conn *sql.DB, queries *db.Queries) gin.HandlerFunc {
 		case float64:
 			userID = int64(v)
 		default:
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("userID_parse_failed", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
 		tx, err := conn.BeginTx(c.Request.Context(), nil)
 		if err != nil {
-			respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+			respond.RespondWithError(c, apperror.NewInternalError("BeginTx", err, apperror.InternalServerMessageCommon))
 			return
 		}
 
@@ -124,21 +126,22 @@ func CreateOrderHandler(conn *sql.DB, queries *db.Queries) gin.HandlerFunc {
 		if err != nil {
 			_ = tx.Rollback()
 
-			switch {
-			case err.Error() == "カートが空です":
-				respond.RespondError(c, http.StatusBadRequest, "カートが空です")
-			case err.Error() == "商品が見つかりません":
-				respond.RespondError(c, http.StatusNotFound, "商品が見つかりません")
-			case err.Error() == "在庫不足です":
-				respond.RespondError(c, http.StatusConflict, "在庫不足です")
-			default:
-				respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+			var ve *apperror.ValidationError
+			var ce *apperror.ConflictError
+			var ne *apperror.NotFoundError
+			var be *apperror.BusinessLogicError
+
+			if errors.As(err, &ve) || errors.As(err, &ne) || errors.As(err, &ce) || errors.As(err, &be) {
+				respond.RespondWithError(c, err)
+				return
 			}
+
+			respond.RespondWithError(c, apperror.NewInternalError("CreateOrder", err, apperror.InternalServerMessageCommon))
 			return
 		}
 
 		if err := tx.Commit(); err != nil {
-			respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+			respond.RespondWithError(c, apperror.NewInternalError("Commit", err, apperror.InternalServerMessageCommon))
 			return
 		}
 		c.JSON(http.StatusCreated, gin.H{"order": order})
@@ -149,17 +152,17 @@ func cancelOrderLogic(ctx context.Context, qtx db.Querier, orderID int64, userID
 	ord, err := qtx.GetOrderByIDForUpdate(ctx, orderID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, errors.New("注文が見つかりません")
+			return nil, apperror.NewNotFoundError("order", orderID, "")
 		}
 		return nil, err
 	}
 	// 所有権チェック
 	if ord.UserID != userID {
-		return nil, errors.New("注文が見つかりません")
+		return nil, apperror.NewNotFoundError("order", orderID, "")
 	}
 
 	if ord.Status != "pending" {
-		return nil, errors.New("この注文はキャンセルできません")
+		return nil, apperror.NewBusinessLogicError("この注文はキャンセルできません")
 	}
 
 	items, err := qtx.ListOrderItemsByOrderID(ctx, orderID)
@@ -192,18 +195,18 @@ func CancelOrderHandler(conn *sql.DB, queries *db.Queries) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		orderIDParam := c.Param("id")
 		if orderIDParam == "" {
-			respond.RespondError(c, http.StatusBadRequest, "注文IDが必要です")
+			respond.RespondWithError(c, apperror.NewValidationError("order", nil, "", apperror.ValidationMessageEssentialOrder))
 			return
 		}
 		orderID, err := strconv.ParseInt(orderIDParam, 10, 64)
 		if err != nil {
-			respond.RespondError(c, http.StatusBadRequest, "無効な注文IDです")
+			respond.RespondWithError(c, apperror.NewValidationError("order", nil, "", apperror.ValidationMessageOrder))
 			return
 		}
 
 		raw, exists := c.Get("userID")
 		if !exists {
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
@@ -216,13 +219,13 @@ func CancelOrderHandler(conn *sql.DB, queries *db.Queries) gin.HandlerFunc {
 		case float64:
 			userID = int64(v)
 		default:
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
 		tx, err := conn.BeginTx(c.Request.Context(), nil)
 		if err != nil {
-			respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+			respond.RespondWithError(c, apperror.NewInternalError("BeginTx", err, apperror.InternalServerMessageCommon))
 			return
 		}
 
@@ -230,19 +233,22 @@ func CancelOrderHandler(conn *sql.DB, queries *db.Queries) gin.HandlerFunc {
 		updated, err := cancelOrderLogic(c.Request.Context(), qtx, orderID, userID)
 		if err != nil {
 			_ = tx.Rollback()
-			switch {
-			case err.Error() == "注文が見つかりません":
-				respond.RespondError(c, http.StatusNotFound, "注文が見つかりません")
-			case err.Error() == "この注文はキャンセルできません":
-				respond.RespondError(c, http.StatusBadRequest, "この注文はキャンセルできません")
-			default:
-				respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+
+			var ve *apperror.ValidationError
+			var ce *apperror.ConflictError
+			var ne *apperror.NotFoundError
+			var be *apperror.BusinessLogicError
+
+			if errors.As(err, &ve) || errors.As(err, &ne) || errors.As(err, &ce) || errors.As(err, &be) {
+				respond.RespondWithError(c, err)
+				return
 			}
+			respond.RespondWithError(c, apperror.NewInternalError("CancelOrder", err, apperror.InternalServerMessageCommon))
 			return
 		}
 
 		if err := tx.Commit(); err != nil {
-			respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+			respond.RespondWithError(c, apperror.NewInternalError("Commit", err, apperror.InternalServerMessageCommon))
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"order": updated})
@@ -290,7 +296,7 @@ func GetOrdersHandler(queries db.Querier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		raw, exists := c.Get("userID")
 		if !exists {
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
@@ -303,19 +309,19 @@ func GetOrdersHandler(queries db.Querier) gin.HandlerFunc {
 		case float64:
 			userID = int64(v)
 		default:
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
 		status := c.Query("status")
 		if !isValidOrderStatus(status) {
-			respond.RespondError(c, http.StatusBadRequest, "無効なステータスです")
+			respond.RespondWithError(c, apperror.NewValidationError("status", status, "", ""))
 			return
 		}
 
 		orders, err := getOrderLogic(c.Request.Context(), queries, userID)
 		if err != nil {
-			respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+			respond.RespondWithError(c, apperror.NewInternalError("GetOrders", err, apperror.InternalServerMessageCommon))
 			return
 		}
 

--- a/backend/handler/order_test.go
+++ b/backend/handler/order_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/handler/testutil"
+	"sol_coffeesys/backend/pkg/apperror"
 	"testing"
 	"time"
 
@@ -23,6 +24,7 @@ func TestCreateOrderLogic(t *testing.T) {
 		userID      int64
 		setupMock   func(*testutil.MockDB)
 		expectedErr string
+		checkErr    func(*testing.T, error)
 	}{
 		{
 			name:   "U1: 単一商品の注文作成",
@@ -230,7 +232,11 @@ func TestCreateOrderLogic(t *testing.T) {
 				m.On("ListCartItemsByUser", mock.Anything, int64(1)).Return(
 					[]db.ListCartItemsByUserRow{}, nil)
 			},
-			expectedErr: "カートが空です",
+			checkErr: func(t *testing.T, err error) {
+				var ve *apperror.ValidationError
+				assert.True(t, errors.As(err, &ve))
+				assert.Equal(t, "cart", ve.Field)
+			},
 		},
 		{
 			name:   "U5：カート内の商品が削除されている",
@@ -263,7 +269,11 @@ func TestCreateOrderLogic(t *testing.T) {
 				m.On("GetProductForUpdate", mock.Anything, int64(999)).Return(
 					db.Product{}, sql.ErrNoRows)
 			},
-			expectedErr: "商品が見つかりません",
+			checkErr: func(t *testing.T, err error) {
+				var ne *apperror.NotFoundError
+				assert.True(t, errors.As(err, &ne))
+				assert.Equal(t, "product", ne.Resource)
+			},
 		},
 		{
 			name:   "U6：在庫不足",
@@ -308,7 +318,11 @@ func TestCreateOrderLogic(t *testing.T) {
 						UpdatedAt:     now,
 					}, nil)
 			},
-			expectedErr: "在庫不足です",
+			checkErr: func(t *testing.T, err error) {
+				var ce *apperror.ConflictError
+				assert.True(t, errors.As(err, &ce))
+				assert.Equal(t, "qty", ce.Field)
+			},
 		},
 		{
 			name:   "U7：DB Error CreateOrder",
@@ -495,7 +509,10 @@ func TestCreateOrderLogic(t *testing.T) {
 			ctx := context.Background()
 			order, err := createOrderLogic(ctx, mockDB, tt.userID)
 
-			if tt.expectedErr != "" {
+			if tt.checkErr != nil {
+				assert.Error(t, err, tt.name)
+				tt.checkErr(t, err)
+			} else if tt.expectedErr != "" {
 				assert.Error(t, err, tt.name)
 				assert.Contains(t, err.Error(), tt.expectedErr)
 			} else {
@@ -516,6 +533,7 @@ func TestCancelOrderLogic(t *testing.T) {
 		userID      int64
 		setupMock   func(*testutil.MockDB)
 		expectedErr string
+		checkErr    func(*testing.T, error)
 	}{
 		{
 			name:    "U1:単一商品のキャンセル",
@@ -570,7 +588,11 @@ func TestCancelOrderLogic(t *testing.T) {
 				m.On("GetOrderByIDForUpdate", mock.Anything, int64(10)).Return(
 					db.GetOrderByIDForUpdateRow{}, sql.ErrNoRows)
 			},
-			expectedErr: "注文が見つかりません",
+			checkErr: func(t *testing.T, err error) {
+				var ne *apperror.NotFoundError
+				assert.True(t, errors.As(err, &ne))
+				assert.Equal(t, "order", ne.Resource)
+			},
 		},
 		{
 			name:    "U4:他ユーザーの注文",
@@ -581,7 +603,11 @@ func TestCancelOrderLogic(t *testing.T) {
 				m.On("GetOrderByIDForUpdate", mock.Anything, int64(11)).Return(
 					db.GetOrderByIDForUpdateRow{ID: 11, UserID: 1, Total: 1000, Status: "pending", CreatedAt: now, UpdatedAt: now}, nil)
 			},
-			expectedErr: "注文が見つかりません",
+			checkErr: func(t *testing.T, err error) {
+				var ne *apperror.NotFoundError
+				assert.True(t, errors.As(err, &ne))
+				assert.Equal(t, "order", ne.Resource)
+			},
 		},
 		{
 			name:    "U5: キャンセル済み",
@@ -639,7 +665,10 @@ func TestCancelOrderLogic(t *testing.T) {
 				tt.setupMock(mockDB)
 			}
 			result, err := cancelOrderLogic(context.Background(), mockDB, tt.orderID, tt.userID)
-			if tt.expectedErr == "" {
+			if tt.checkErr != nil {
+				assert.Error(t, err, tt.name)
+				tt.checkErr(t, err)
+			} else if tt.expectedErr == "" {
 				assert.NoError(t, err)
 				assert.NotNil(t, result)
 			} else {

--- a/backend/handler/product.go
+++ b/backend/handler/product.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"sol_coffeesys/backend/db"
+	"sol_coffeesys/backend/pkg/apperror"
 	"sol_coffeesys/backend/pkg/respond"
 	"strconv"
 	"time"
@@ -45,7 +46,7 @@ func ListProductsHandler(q db.Querier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		products, err := q.ListProducts(c.Request.Context())
 		if err != nil {
-			respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+			respond.RespondWithError(c, apperror.NewInternalError("ListProducts", err, apperror.InternalServerMessageCommon))
 			return
 		}
 		resp := make([]ProductResponse, 0, len(products))
@@ -81,16 +82,16 @@ func GetProductHandler(q db.Querier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 		if err != nil {
-			respond.RespondError(c, http.StatusBadRequest, "IDが正しくありません")
+			respond.RespondWithError(c, apperror.NewValidationError("id", id, "", ""))
 			return
 		}
 
 		product, err := q.GetProduct(c.Request.Context(), int64(id))
 		if err != nil {
 			if err == sql.ErrNoRows {
-				respond.RespondError(c, http.StatusNotFound, "商品が見つかりません")
+				respond.RespondWithError(c, apperror.NewNotFoundError("product", id, ""))
 			} else {
-				respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+				respond.RespondWithError(c, apperror.NewInternalError("GetProduct", err, apperror.InternalServerMessageCommon))
 			}
 			return
 		}
@@ -123,33 +124,33 @@ func CreateProductHandler(q db.Querier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req CreateProductHandlerRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
-			respond.RespondError(c, http.StatusBadRequest, "リクエスト形式が正しくありません")
+			respond.RespondWithError(c, apperror.NewValidationError("request", nil, "", ""))
 			return
 		}
 
 		if req.Name == "" {
-			respond.RespondError(c, http.StatusBadRequest, "nameは必須です")
+			respond.RespondWithError(c, apperror.NewValidationError("name", nil, "", ""))
 			return
 		}
 		if req.Price <= 0 {
-			respond.RespondError(c, http.StatusBadRequest, "priceは正の整数である必要があります")
+			respond.RespondWithError(c, apperror.NewValidationError("price", req.Price, "", ""))
 			return
 		}
 		if req.Sku == "" {
-			respond.RespondError(c, http.StatusBadRequest, "skuは必須です")
+			respond.RespondWithError(c, apperror.NewValidationError("sku", nil, "", ""))
 			return
 		}
 
 		if len(req.Name) > 255 {
-			respond.RespondError(c, http.StatusBadRequest, "nameは255文字以内である必要があります")
+			respond.RespondWithError(c, apperror.NewValidationError("", req.Name, "", apperror.ValidationMessageNameLength))
 			return
 		}
 
 		if _, err := q.GetCategory(c.Request.Context(), req.CategoryID); err != nil {
 			if err == sql.ErrNoRows {
-				respond.RespondError(c, http.StatusNotFound, "カテゴリが見つかりません")
+				respond.RespondWithError(c, apperror.NewNotFoundError("category", req.CategoryID, ""))
 			} else {
-				respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+				respond.RespondWithError(c, apperror.NewInternalError("GetCategory", err, apperror.InternalServerMessageCommon))
 			}
 			return
 		}
@@ -176,10 +177,10 @@ func CreateProductHandler(q db.Querier) gin.HandlerFunc {
 		if err != nil {
 			var pqErr *pq.Error
 			if errors.As(err, &pqErr) && pqErr.Code == "23505" {
-				respond.RespondError(c, http.StatusConflict, "SKUが既に存在します")
+				respond.RespondWithError(c, apperror.NewConflictError("sku", req.Sku, ""))
 				return
 			}
-			respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+			respond.RespondWithError(c, apperror.NewInternalError("CreateProduct", err, apperror.InternalServerMessageCommon))
 			return
 		}
 
@@ -213,39 +214,39 @@ func UpdateProductHandler(q db.Querier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 		if err != nil {
-			respond.RespondError(c, http.StatusBadRequest, "IDが正しくありません")
+			respond.RespondWithError(c, apperror.NewValidationError("id", id, "", ""))
 			return
 		}
 		var req UpdateProductHandlerRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
-			respond.RespondError(c, http.StatusBadRequest, "リクエスト形式が正しくありません")
+			respond.RespondWithError(c, apperror.NewValidationError("request", nil, "", ""))
 			return
 		}
 
 		if req.Name == "" {
-			respond.RespondError(c, http.StatusBadRequest, "nameは必須です")
+			respond.RespondWithError(c, apperror.NewValidationError("name", nil, "", ""))
 			return
 		}
 		if req.Price <= 0 {
-			respond.RespondError(c, http.StatusBadRequest, "priceは正の整数である必要があります")
+			respond.RespondWithError(c, apperror.NewValidationError("price", req.Price, "", ""))
 			return
 		}
 		if req.Sku == "" {
-			respond.RespondError(c, http.StatusBadRequest, "skuは必須です")
+			respond.RespondWithError(c, apperror.NewValidationError("sku", nil, "", ""))
 			return
 		}
 
 		if len(req.Name) > 255 {
-			respond.RespondError(c, http.StatusBadRequest, "nameは255文字以内である必要があります")
+			respond.RespondWithError(c, apperror.NewValidationError("", req.Name, "", apperror.ValidationMessageNameLength))
 			return
 		}
 
 		// category 存在確認
 		if _, err := q.GetCategory(c.Request.Context(), req.CategoryID); err != nil {
 			if err == sql.ErrNoRows {
-				respond.RespondError(c, http.StatusNotFound, "カテゴリが見つかりません")
+				respond.RespondWithError(c, apperror.NewNotFoundError("category", req.CategoryID, ""))
 			} else {
-				respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+				respond.RespondWithError(c, apperror.NewInternalError("GetCategory", err, apperror.InternalServerMessageCommon))
 			}
 			return
 		}
@@ -273,14 +274,14 @@ func UpdateProductHandler(q db.Querier) gin.HandlerFunc {
 		if err != nil {
 			var pqErr *pq.Error
 			if errors.As(err, &pqErr) && pqErr.Code == "23505" {
-				respond.RespondError(c, http.StatusConflict, "SKUが既に存在します")
+				respond.RespondWithError(c, apperror.NewConflictError("sku", req.Sku, ""))
 				return
 			}
 
 			if err == sql.ErrNoRows {
-				respond.RespondError(c, http.StatusNotFound, "商品が見つかりません")
+				respond.RespondWithError(c, apperror.NewNotFoundError("product", id, ""))
 			} else {
-				respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+				respond.RespondWithError(c, apperror.NewInternalError("UpdateProduct", err, apperror.InternalServerMessageCommon))
 			}
 			return
 		}
@@ -315,15 +316,15 @@ func DeleteProductHandler(q db.Querier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 		if err != nil {
-			respond.RespondError(c, http.StatusBadRequest, "IDが正しくありません")
+			respond.RespondWithError(c, apperror.NewValidationError("id", id, "", ""))
 			return
 		}
 		err = q.DeleteProduct(c.Request.Context(), int64(id))
 		if err != nil {
 			if err == sql.ErrNoRows {
-				respond.RespondError(c, http.StatusNotFound, "商品が見つかりません")
+				respond.RespondWithError(c, apperror.NewNotFoundError("product", id, ""))
 			} else {
-				respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+				respond.RespondWithError(c, apperror.NewInternalError("DeleteProduct", err, apperror.InternalServerMessageCommon))
 			}
 			return
 		}

--- a/backend/handler/refresh.go
+++ b/backend/handler/refresh.go
@@ -55,7 +55,7 @@ func RefreshTokenHandler(q db.Querier, tokenGenerator auth.TokenGenerator) gin.H
 
 		newRefresh, _, expiresAt, err := GenerateRefreshToken(c.Request.Context(), q, user.ID)
 		if err != nil {
-			respond.RespondWithError(c, apperror.NewInternalError("GenerateRefresToken", err, apperror.InternalServerMessageRefresh))
+			respond.RespondWithError(c, apperror.NewInternalError("GenerateRefreshToken", err, apperror.InternalServerMessageRefresh))
 			c.Abort()
 			return
 		}

--- a/backend/handler/refresh.go
+++ b/backend/handler/refresh.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"sol_coffeesys/backend/auth"
 	"sol_coffeesys/backend/db"
+	"sol_coffeesys/backend/pkg/apperror"
 	"sol_coffeesys/backend/pkg/respond"
 	"time"
 
@@ -18,7 +19,7 @@ func RefreshTokenHandler(q db.Querier, tokenGenerator auth.TokenGenerator) gin.H
 	return func(c *gin.Context) {
 		cookie, err := c.Request.Cookie("refresh_token")
 		if err != nil {
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("invalid_refresh_token", apperror.UnauthorizedMessageAuth))
 			return
 		}
 		sum := sha256.Sum256([]byte(cookie.Value))
@@ -27,16 +28,16 @@ func RefreshTokenHandler(q db.Querier, tokenGenerator auth.TokenGenerator) gin.H
 		rt, err := q.GetRefreshTokenByHash(c.Request.Context(), hash)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+				respond.RespondWithError(c, apperror.NewUnauthorizedError("token_not_found", apperror.UnauthorizedMessageAuth))
 			} else {
-				respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+				respond.RespondWithError(c, apperror.NewInternalError("GetRefreshTokenByHash", err, apperror.InternalServerMessageCommon))
 			}
 			c.Abort()
 			return
 		}
 
 		if rt.RevokedAt.Valid || rt.ExpiresAt.Before(time.Now()) {
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("refresh_token_revoked_alredy", apperror.UnauthorizedMessageAuth))
 			c.Abort()
 			return
 		}
@@ -44,9 +45,9 @@ func RefreshTokenHandler(q db.Querier, tokenGenerator auth.TokenGenerator) gin.H
 		user, err := q.GetUserByID(c.Request.Context(), rt.UserID)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+				respond.RespondWithError(c, apperror.NewUnauthorizedError("token_not_found", apperror.UnauthorizedMessageAuth))
 			} else {
-				respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+				respond.RespondWithError(c, apperror.NewInternalError("GetUserByID", err, apperror.InternalServerMessageCommon))
 			}
 			c.Abort()
 			return
@@ -54,7 +55,7 @@ func RefreshTokenHandler(q db.Querier, tokenGenerator auth.TokenGenerator) gin.H
 
 		newRefresh, _, expiresAt, err := GenerateRefreshToken(c.Request.Context(), q, user.ID)
 		if err != nil {
-			respond.RespondError(c, http.StatusInternalServerError, "リフレッシュトークンの保存に失敗しました")
+			respond.RespondWithError(c, apperror.NewInternalError("GenerateRefresToken", err, apperror.InternalServerMessageRefresh))
 			c.Abort()
 			return
 		}
@@ -63,7 +64,7 @@ func RefreshTokenHandler(q db.Querier, tokenGenerator auth.TokenGenerator) gin.H
 			if errors.Is(err, sql.ErrNoRows) {
 				// 存在しないトークンは無視
 			} else {
-				respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+				respond.RespondWithError(c, apperror.NewInternalError("RevokeRefreshByRaw", err, apperror.InternalServerMessageCommon))
 				c.Abort()
 				return
 			}
@@ -71,7 +72,7 @@ func RefreshTokenHandler(q db.Querier, tokenGenerator auth.TokenGenerator) gin.H
 
 		accessToken, err := tokenGenerator.GenerateToken(user.ID)
 		if err != nil {
-			respond.RespondError(c, http.StatusInternalServerError, "トークンの生成に失敗しました")
+			respond.RespondWithError(c, apperror.NewInternalError("GenerateToken", err, apperror.InternalServerMessageGenToken))
 			c.Abort()
 			return
 		}
@@ -151,7 +152,7 @@ func RevokeRefreshHandler(q db.Querier) gin.HandlerFunc {
 			if errors.Is(err, sql.ErrNoRows) {
 
 			} else {
-				respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+				respond.RespondWithError(c, apperror.NewInternalError("RevokeRefreshByRaw", err, apperror.InternalServerMessageCommon))
 				c.Abort()
 				return
 			}

--- a/backend/handler/user.go
+++ b/backend/handler/user.go
@@ -3,10 +3,10 @@ package handler
 import (
 	"database/sql"
 	"errors"
-	"fmt"
 	"net/http"
 	"sol_coffeesys/backend/auth"
 	"sol_coffeesys/backend/db"
+	"sol_coffeesys/backend/pkg/apperror"
 	"sol_coffeesys/backend/pkg/respond"
 	"sol_coffeesys/backend/pkg/validation"
 	"strconv"
@@ -29,7 +29,7 @@ var BcryptGenerateFromPassword = bcrypt.GenerateFromPassword
 func HashPassword(password string) (string, error) {
 	hashed, err := BcryptGenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
-		return "", fmt.Errorf("パスワードのハッシュ化に失敗しました: %w", err)
+		return "", apperror.NewInternalError("HashPassword", err, apperror.InternalServerMessagePassword)
 	}
 	return string(hashed), nil
 }
@@ -40,28 +40,30 @@ func RegisterUserHandler(q db.Querier) gin.HandlerFunc {
 		var req RegisterRequest
 
 		if err := c.ShouldBindJSON(&req); err != nil {
-			respond.RespondError(c, http.StatusBadRequest, "リクエスト形式が正しくありません")
+			c.Error(err)
+			respond.RespondWithError(c, apperror.NewValidationError("request", nil, "bind", apperror.ValidationMessageRequest))
 			return
 		}
 		// バリデーションチェック
 		if err := validation.ValidateRegisterRequest(req.Name, req.Email, req.Password); err != nil {
 			switch {
 			case errors.Is(err, validation.ErrInvalidName):
-				respond.RespondError(c, http.StatusBadRequest, "名前は必須です")
+				respond.RespondWithError(c, apperror.NewValidationError("name", nil, "", ""))
 			case errors.Is(err, validation.ErrInvalidEmail):
-				respond.RespondError(c, http.StatusBadRequest, "メールアドレスの形式が正しくありません")
+				respond.RespondWithError(c, apperror.NewValidationError("email", nil, "", ""))
 			case errors.Is(err, validation.ErrInvalidPassword):
-				respond.RespondError(c, http.StatusBadRequest, "パスワードの形式が正しくありません")
+				respond.RespondWithError(c, apperror.NewValidationError("password", nil, "", ""))
 			default:
 				c.Error(err)
-				respond.RespondError(c, http.StatusBadRequest, "入力が不正です")
+				respond.RespondWithError(c, apperror.NewValidationError("request", nil, "", ""))
 			}
 			return
 		}
 
 		hashed, err := HashPassword(req.Password)
 		if err != nil {
-			respond.RespondError(c, http.StatusInternalServerError, "パスワードのハッシュ化に失敗しました")
+			c.Error(err)
+			respond.RespondWithError(c, err)
 			return
 		}
 
@@ -75,11 +77,11 @@ func RegisterUserHandler(q db.Querier) gin.HandlerFunc {
 			var pqErr *pq.Error
 			if errors.As(err, &pqErr) {
 				if pqErr.Code == "23505" {
-					respond.RespondError(c, http.StatusBadRequest, "このメールアドレスは既に登録されています")
+					respond.RespondWithError(c, apperror.NewValidationError("email", req.Email, "", apperror.ValidationMessageConflictedEmail))
 					return
 				}
 			}
-			respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+			respond.RespondWithError(c, apperror.NewInternalError("CreateUser", err, apperror.InternalServerMessageCommon))
 			return
 		}
 
@@ -98,42 +100,42 @@ func LoginUserHandler(q db.Querier, tokenGenerator auth.TokenGenerator) gin.Hand
 	return func(c *gin.Context) {
 		var req LoginRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
-			fmt.Printf("Bind Error: %v\n", err)
-			respond.RespondError(c, http.StatusBadRequest, "リクエスト形式が正しくありません")
+			c.Error(err)
+			respond.RespondWithError(c, apperror.NewValidationError("request", nil, "bind", apperror.ValidationMessageRequest))
 			return
 		}
 
 		// バリデーションチェック
 		if err := validation.ValidateEmail(req.Email); err != nil {
-			respond.RespondError(c, http.StatusBadRequest, "メールアドレスの形式が正しくありません")
+			respond.RespondWithError(c, apperror.NewValidationError("email", nil, "", ""))
 			return
 		}
 		if err := validation.ValidatePassword(req.Password); err != nil {
-			respond.RespondError(c, http.StatusBadRequest, "パスワードの形式が正しくありません")
+			respond.RespondWithError(c, apperror.NewValidationError("password", nil, "", ""))
 			return
 		}
 
 		user, err := q.GetUserByEmail(c.Request.Context(), req.Email)
 		if err != nil {
-			respond.RespondError(c, http.StatusUnauthorized, "メールアドレスまたはパスワードが正しくありません")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageEmailOrPassword))
 			return
 		}
 		err = bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(req.Password))
 		if err != nil {
-			respond.RespondError(c, http.StatusUnauthorized, "メールアドレスまたはパスワードが正しくありません")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageEmailOrPassword))
 			return
 		}
 
 		token, err := tokenGenerator.GenerateToken(user.ID)
 		// token, err := auth.GenerateToken(int32(user.ID))
 		if err != nil {
-			respond.RespondError(c, http.StatusInternalServerError, "トークンの生成に失敗しました")
+			respond.RespondWithError(c, apperror.NewInternalError("GenerateToken", err, apperror.InternalServerMessageGenToken))
 			return
 		}
 
 		refreshToken, _, expiresAt, err := GenerateRefreshToken(c.Request.Context(), q, user.ID)
 		if err != nil {
-			respond.RespondError(c, http.StatusInternalServerError, "リフレッシュトークンの保存に失敗しました")
+			respond.RespondWithError(c, apperror.NewInternalError("GenerateRefreshToken", err, apperror.InternalServerMessageRefresh))
 			return
 		}
 
@@ -188,29 +190,29 @@ func SetUserRoleHandler(q db.Querier) gin.HandlerFunc {
 		idStr := c.Param("id")
 		userID, err := strconv.ParseInt(idStr, 10, 64)
 		if err != nil {
-			respond.RespondError(c, http.StatusBadRequest, "無効なユーザーIDです")
+			respond.RespondWithError(c, apperror.NewValidationError("id", nil, "", ""))
 			return
 		}
 		raw, exists := c.Get("userID")
 		if !exists {
-			respond.RespondError(c, http.StatusUnauthorized, "認証が必要です")
+			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 		adminID := raw.(int64)
 
 		if adminID == userID {
-			respond.RespondError(c, http.StatusBadRequest, "自分自身のロールは変更できません")
+			respond.RespondWithError(c, apperror.NewBusinessLogicError(apperror.BusinessLogicMessageRole))
 			return
 		}
 
 		var req SetUserRoleRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
-			respond.RespondError(c, http.StatusBadRequest, "リクエストが不正です")
+			respond.RespondWithError(c, apperror.NewValidationError("request", nil, "bind", apperror.ValidationMessageRequest))
 			return
 		}
 
 		if err := validation.ValidateRole(req.Role); err != nil {
-			respond.RespondError(c, http.StatusBadRequest, "無効なロール")
+			respond.RespondWithError(c, apperror.NewValidationError("role", nil, "", ""))
 			return
 		}
 
@@ -220,10 +222,10 @@ func SetUserRoleHandler(q db.Querier) gin.HandlerFunc {
 		})
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				respond.RespondError(c, http.StatusNotFound, "ユーザーが見つかりません")
+				respond.RespondWithError(c, apperror.NewNotFoundError("user", userID, ""))
 				return
 			}
-			respond.RespondError(c, http.StatusInternalServerError, "予期せぬエラーが発生しました")
+			respond.RespondWithError(c, apperror.NewInternalError("UpdateUserRole", err, apperror.InternalServerMessageCommon))
 			return
 		}
 		c.JSON(http.StatusOK, user)

--- a/backend/handler/user_test.go
+++ b/backend/handler/user_test.go
@@ -388,7 +388,7 @@ func TestSetUserRoleHandler(t *testing.T) {
 			},
 			expectedStatus: http.StatusBadRequest,
 			checkResponse: func(t *testing.T, resp map[string]interface{}) {
-				assert.Equal(t, resp["error"], "無効なロール")
+				assert.Equal(t, resp["error"], "無効なロールです")
 			},
 		},
 		{
@@ -442,7 +442,7 @@ func TestSetUserRoleHandler(t *testing.T) {
 			},
 			expectedStatus: http.StatusBadRequest,
 			checkResponse: func(t *testing.T, resp map[string]interface{}) {
-				assert.Contains(t, resp["error"], "リクエストが不正です")
+				assert.Contains(t, resp["error"], "リクエスト形式が正しくありません")
 			},
 		},
 	}

--- a/backend/pkg/apperror/http.go
+++ b/backend/pkg/apperror/http.go
@@ -1,0 +1,110 @@
+package apperror
+
+import (
+	"errors"
+	"net/http"
+)
+
+var validationMessages = map[string]string{
+	"email":    ValidationMessageEmail,
+	"password": ValidationMessagePassword,
+	"name":     ValidationMessageName,
+	"sku":      ValidationMessageSku,
+	"id":       ValidationMessageID,
+	"order":    ValidationMessageOrder,
+	"status":   ValidationMessageStatus,
+	"price":    ValidationMessagePrice,
+	"request":  ValidationMessageRequest,
+	"role":     ValidationMessageRole,
+	"cart":     ValidationMessageCart,
+	"category": ValidationMessageCategory,
+	"qty":      ValidationMessageQty,
+}
+
+var conflictMessages = map[string]string{
+	"qty": ConflictMessageQty,
+	"sku": ConflictMessageSku,
+}
+
+var notFoundMessages = map[string]string{
+	"product":   NotFoundMessageProduct,
+	"cart":      NotFoundMessageCart,
+	"cart_item": NotFoundMessageCartItem,
+	"user":      NotFoundMessageUser,
+	"category":  NotFoundMessageCategory,
+	"order":     NotFoundMessageOrder,
+}
+
+func ToHTTP(err error) (status int, message string) {
+	if err == nil {
+		return http.StatusInternalServerError, InternalServerMessageCommon
+	}
+
+	var ve *ValidationError
+	if errors.As(err, &ve) {
+		if ve.Message != "" {
+			return http.StatusBadRequest, ve.Message
+		}
+		if m, ok := validationMessages[ve.Field]; ok {
+			return http.StatusBadRequest, m
+		}
+		return http.StatusBadRequest, ValidationMessageGeneric
+	}
+
+	var ce *ConflictError
+	if errors.As(err, &ce) {
+		if ce.Message != "" {
+			return http.StatusConflict, ce.Message
+		}
+		if m, ok := conflictMessages[ce.Field]; ok {
+			return http.StatusConflict, m
+		}
+		return http.StatusConflict, ConflictMessageGeneric
+	}
+
+	var ne *NotFoundError
+	if errors.As(err, &ne) {
+		if ne.Message != "" {
+			return http.StatusNotFound, ne.Message
+		}
+		if m, ok := notFoundMessages[ne.Resource]; ok {
+			return http.StatusNotFound, m
+		}
+		return http.StatusNotFound, NotFoundMessageGeneric
+	}
+
+	var ue *UnauthorizedError
+	if errors.As(err, &ue) {
+		if ue.Message != "" {
+			return http.StatusUnauthorized, ue.Message
+		}
+		return http.StatusUnauthorized, UnauthorizedMessageGeneric
+	}
+
+	var fe *ForbiddenError
+	if errors.As(err, &fe) {
+		if fe.Message != "" {
+			return http.StatusForbidden, fe.Message
+		}
+		return http.StatusForbidden, ForbiddenMessageGeneric
+	}
+
+	var be *BusinessLogicError
+	if errors.As(err, &be) {
+		if be.Message != "" {
+			return http.StatusBadRequest, be.Message
+		}
+		return http.StatusBadRequest, BusinessLogicMessageGeneric
+	}
+
+	var ie *InternalError
+	if errors.As(err, &ie) {
+		if ie.Message != "" {
+			return http.StatusInternalServerError, ie.Message
+		}
+		return http.StatusInternalServerError, InternalServerMessageCommon
+	}
+
+	// fallback
+	return http.StatusInternalServerError, InternalServerMessageCommon
+}

--- a/backend/pkg/apperror/http_test.go
+++ b/backend/pkg/apperror/http_test.go
@@ -1,0 +1,128 @@
+package apperror
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+func TestToHTTP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantMsg    string
+	}{
+		{
+			name:       "nil errorは500共通メッセージ",
+			err:        nil,
+			wantStatus: http.StatusInternalServerError,
+			wantMsg:    InternalServerMessageCommon,
+		},
+		{
+			name:       "Validation: Message優先",
+			err:        NewValidationError("email", "a@example.com", "format", "custom validation"),
+			wantStatus: http.StatusBadRequest,
+			wantMsg:    "custom validation",
+		},
+		{
+			name:       "Validation: Field map email",
+			err:        NewValidationError("email", "a@example.com", "format", ""),
+			wantStatus: http.StatusBadRequest,
+			wantMsg:    ValidationMessageEmail,
+		},
+		{
+			name:       "Validation: 未知fieldは generic",
+			err:        NewValidationError("unkown", "x", "rule", ""),
+			wantStatus: http.StatusBadRequest,
+			wantMsg:    ValidationMessageGeneric,
+		},
+		{
+			name:       "Conflict: Message優先",
+			err:        NewConflictError("sku", "ABC", "custom conflict"),
+			wantStatus: http.StatusConflict,
+			wantMsg:    "custom conflict",
+		},
+		{
+			name:       "Conflict: field map qty",
+			err:        NewConflictError("qty", "1", ""),
+			wantStatus: http.StatusConflict,
+			wantMsg:    ConflictMessageQty,
+		},
+		{
+			name:       "Conflict: 未知fieldはfallback",
+			err:        NewConflictError("unkown", "x", ""),
+			wantStatus: http.StatusConflict,
+			wantMsg:    ConflictMessageGeneric,
+		},
+		{
+			name:       "NotFound: resource map cart_item",
+			err:        NewNotFoundError("cart_item", 1, ""),
+			wantStatus: http.StatusNotFound,
+			wantMsg:    NotFoundMessageCartItem,
+		},
+		{
+			name:       "NotFound: 未知resourceはfallback",
+			err:        NewNotFoundError("unknown", 1, ""),
+			wantStatus: http.StatusNotFound,
+			wantMsg:    NotFoundMessageGeneric,
+		},
+		{
+			name:       "Unauthorized: Message優先",
+			err:        NewUnauthorizedError("invalid_credentials", "custom unauthorized"),
+			wantStatus: http.StatusUnauthorized,
+			wantMsg:    "custom unauthorized",
+		},
+		{
+			name:       "Unauthorized: Message空はfallback",
+			err:        NewUnauthorizedError("token_not_found", ""),
+			wantStatus: http.StatusUnauthorized,
+			wantMsg:    UnauthorizedMessageGeneric,
+		},
+		{
+			name:       "Forbidden: Message空はfallback",
+			err:        NewForbiddenError("admin", "user", ""),
+			wantStatus: http.StatusForbidden,
+			wantMsg:    ForbiddenMessageGeneric,
+		},
+		{
+			name:       "BusinessLogic: Message空はfallback",
+			err:        NewBusinessLogicError(""),
+			wantStatus: http.StatusBadRequest,
+			wantMsg:    BusinessLogicMessageGeneric,
+		},
+		{
+			name:       "Internal: Message優先",
+			err:        NewInternalError("CreateUser", errors.New("db"), "custom internal error"),
+			wantStatus: http.StatusInternalServerError,
+			wantMsg:    "custom internal error",
+		},
+		{
+			name:       "Internal: Message空は common fallback",
+			err:        NewInternalError("CreateUser", errors.New("db"), ""),
+			wantStatus: http.StatusInternalServerError,
+			wantMsg:    InternalServerMessageCommon,
+		},
+		{
+			name:       "未知errorは500 common",
+			err:        errors.New("unknown"),
+			wantStatus: http.StatusInternalServerError,
+			wantMsg:    InternalServerMessageCommon,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotStatus, gotMsg := ToHTTP(tt.err)
+			if gotStatus != tt.wantStatus {
+				t.Fatalf("status mismatch: got=%d want=%d", gotStatus, tt.wantStatus)
+			}
+			if gotMsg != tt.wantMsg {
+				t.Fatalf("message mismatch: got=%q want=%q", gotMsg, tt.wantMsg)
+			}
+		})
+	}
+}

--- a/backend/pkg/apperror/messages.go
+++ b/backend/pkg/apperror/messages.go
@@ -51,4 +51,5 @@ const (
 	InternalServerMessageCommon   = "予期せぬエラーが発生しました"
 	InternalServerMessageRefresh  = "リフレッシュトークンの保存に失敗しました"
 	InternalServerMessageGenToken = "トークンの生成に失敗しました"
+	InternalServerMessagePassword = "パスワードのハッシュ化に失敗しました"
 )

--- a/backend/pkg/apperror/messages.go
+++ b/backend/pkg/apperror/messages.go
@@ -2,6 +2,7 @@ package apperror
 
 const (
 	// 400
+	ValidationMessageGeneric         = "入力が不正です"
 	ValidationMessageEmail           = "メールアドレスの形式が正しくありません"
 	ValidationMessagePassword        = "パスワードの形式が正しくありません"
 	ValidationMessageName            = "名前は必須です"
@@ -16,14 +17,15 @@ const (
 	ValidationMessageCart            = "カートが空です"
 	ValidationMessageCategory        = "カテゴリ名は必須です"
 	ValidationMessageQty             = "在庫は1以上である必要があります"
-	ValidationMessageGeneric         = "入力が不正です"
 	ValidationMessageEssentialOrder  = "注文IDが必要です"
 	ValidationMessageConflictedEmail = "このメールアドレスは既に登録されています"
 
 	// 400
-	BusinessLogicMessageRole = "自分自身のロールは変更できません"
+	BusinessLogicMessageGeneric = "この操作は実行できません"
+	BusinessLogicMessageRole    = "自分自身のロールは変更できません"
 
 	// 404
+	NotFoundMessageGeneric  = "リソースが見つかりません"
 	NotFoundMessageProduct  = "商品が見つかりません"
 	NotFoundMessageCart     = "カートが見つかりません"
 	NotFoundMessageCartItem = "カートアイテムが見つかりません"
@@ -32,15 +34,18 @@ const (
 	NotFoundMessageOrder    = "注文が見つかりません"
 
 	// 409
-	ConflictMessageQty = "在庫不足です"
-	ConflictMessageSku = "SKUが既に存在します"
+	ConflictMessageGeneric = "競合が発生しました"
+	ConflictMessageQty     = "在庫不足です"
+	ConflictMessageSku     = "SKUが既に存在します"
 
 	// 401
+	UnauthorizedMessageGeneric         = "認証エラーが発生しました"
 	UnauthorizedMessageAuth            = "認証が必要です"
 	UnauthorizedMessageEmailOrPassword = "メールアドレスまたはパスワードが正しくありません"
 
 	// 403
-	ForbiddenMessageAdmin = "管理者権限が必要です"
+	ForbiddenMessageGeneric = "権限エラーが発生しました"
+	ForbiddenMessageAdmin   = "管理者権限が必要です"
 
 	// 500
 	InternalServerMessageCommon = "予期せぬエラーが発生しました"

--- a/backend/pkg/apperror/messages.go
+++ b/backend/pkg/apperror/messages.go
@@ -48,5 +48,7 @@ const (
 	ForbiddenMessageAdmin   = "管理者権限が必要です"
 
 	// 500
-	InternalServerMessageCommon = "予期せぬエラーが発生しました"
+	InternalServerMessageCommon   = "予期せぬエラーが発生しました"
+	InternalServerMessageRefresh  = "リフレッシュトークンの保存に失敗しました"
+	InternalServerMessageGenToken = "トークンの生成に失敗しました"
 )

--- a/backend/pkg/apperror/types.go
+++ b/backend/pkg/apperror/types.go
@@ -17,10 +17,14 @@ func NewValidationError(field string, value any, rule string, message string) *V
 			v = maskEmail(s)
 		}
 	}
+	var valueType string
+	if value != nil {
+		valueType = reflect.TypeOf(value).String()
+	}
 	return &ValidationError{
 		Field:     field,
 		Value:     v,
-		ValueType: reflect.TypeOf(value).String(),
+		ValueType: valueType,
 		Rule:      rule,
 		Message:   message,
 	}

--- a/backend/pkg/apperror/types_test.go
+++ b/backend/pkg/apperror/types_test.go
@@ -318,7 +318,7 @@ func TestNewForbiddenError(t *testing.T) {
 				t.Fatalf("RequiredRole = %q, want %q", err.RequiredRole, tt.requiredRole)
 			}
 			if err.UserRole != tt.userRole {
-				t.Fatalf("UserROle = %q, want %q", err.UserRole, tt.userRole)
+				t.Fatalf("UserRole = %q, want %q", err.UserRole, tt.userRole)
 			}
 			if err.Message != tt.message {
 				t.Fatalf("Message = %q, want %q", err.Message, tt.message)

--- a/backend/pkg/respond/error.go
+++ b/backend/pkg/respond/error.go
@@ -1,6 +1,10 @@
 package respond
 
-import "github.com/gin-gonic/gin"
+import (
+	"sol_coffeesys/backend/pkg/apperror"
+
+	"github.com/gin-gonic/gin"
+)
 
 type ErrorResponse struct {
 	Error string `json:"error"`
@@ -13,4 +17,9 @@ type ValidationError struct {
 
 func RespondError(c *gin.Context, status int, message string) {
 	c.JSON(status, ErrorResponse{Error: message})
+}
+
+func RespondWithError(c *gin.Context, err error) {
+	status, msg := apperror.ToHTTP(err)
+	c.JSON(status, ErrorResponse{Error: msg})
 }

--- a/backend/pkg/respond/error.go
+++ b/backend/pkg/respond/error.go
@@ -10,11 +10,6 @@ type ErrorResponse struct {
 	Error string `json:"error"`
 }
 
-type ValidationError struct {
-	Error  string                 `json:"error"`
-	Fields map[string]interface{} `json:"fields,omitempty"`
-}
-
 func RespondWithError(c *gin.Context, err error) {
 	status, msg := apperror.ToHTTP(err)
 	c.JSON(status, ErrorResponse{Error: msg})

--- a/backend/pkg/respond/error.go
+++ b/backend/pkg/respond/error.go
@@ -15,10 +15,6 @@ type ValidationError struct {
 	Fields map[string]interface{} `json:"fields,omitempty"`
 }
 
-func RespondError(c *gin.Context, status int, message string) {
-	c.JSON(status, ErrorResponse{Error: message})
-}
-
 func RespondWithError(c *gin.Context, err error) {
 	status, msg := apperror.ToHTTP(err)
 	c.JSON(status, ErrorResponse{Error: msg})

--- a/doc/memo/2026/04/2026-04-22_learning.md
+++ b/doc/memo/2026/04/2026-04-22_learning.md
@@ -1,0 +1,44 @@
+# 学習記録 2026-04-22
+
+## セッション 1 (07:29)
+
+### 取り組んだタスク
+- `apperror.ToHTTP` の設計・実装・テスト完了（`backend/pkg/apperror/http.go`, `messages.go`, `http_test.go`）。16ケースのユニットテストが PASS。
+- `backend/pkg/respond/error.go` に `RespondWithError` 実装、`apperror.ToHTTP` を使用するように統一。
+- `backend/handler/cart.go` を `RespondWithError` + `apperror` 型に全面置換。`ErrNoRows` 発生時の zero-value ID バグ修正（URLパラメータ `id` / `userID` を利用）。Operation 名を全箇所埋める。`RespondError` を排除。
+- `backend/handler/category.go` をレビュー・一部修正（`DeleteCategoryHandler` の `err`→`respErr` 修正、バリデーションフィールドを `category` に統一、204レスポンスは `c.Status` に揃えることを推奨）。
+- `backend/pkg/apperror/types.go` の `NewValidationError` における nil 参照パニックを修正（`reflect.TypeOf(value)` が nil になるケースのガード追加）。
+
+### ユーザーが質問した内容（直近）
+- `cart.go` の最終版をレビューしてほしい（ユーザー: 「直しました」）
+- `category.go` のレビューを依頼
+- 作業を一旦終了するのでここまでをログ記録してほしい
+- フィールド名の判断: カテゴリの Name はドメインとして `category` を使うべきか
+
+### 躓いたポイントと解決策
+- NewValidationError の panic: `reflect.TypeOf(value).String()` が value==nil のときにパニック。→ `value != nil` をチェックしてから型名を取る実装に修正。
+- `ErrNoRows` 時の NotFound エラーで zero-value の `item.ID` / `cart.ID` を使用していたため誤ったIDが返る。→ リクエストパラメータ（`id`）または `userID` を NotFound の ID 値として使用するよう修正。
+- `DeleteCategoryHandler` のエラーハンドリングで誤って `err` を `NewInternalError` に渡していた（`respErr` を渡すべき）。→ 修正。
+- 204 レスポンスで `c.JSON(http.StatusNoContent, nil)` を使っている箇所があり意味的に不適切。→ `c.Status(http.StatusNoContent)` に統一推奨。
+- バリデーションメッセージのマッピングで `name` と `category` の混乱が発生。→ ドメイン固有の検証は `category` を用いる（テスト期待値に合わせ修正）。
+
+### テストと結果
+- 初期に `AddToCartHandler` のテストで `NewValidationError` による nil ポイント参照で panic が発生。→ `types.go` の修正で解消。
+- 現時点で `go test ./handler/...` は成功（handler パッケージのテストは全パス）。
+
+### 変更済み／確認ファイル
+- backend/pkg/apperror/types.go (NewValidationError 修正)
+- backend/pkg/apperror/http.go, messages.go, http_test.go
+- backend/pkg/respond/error.go
+- backend/handler/cart.go
+- backend/handler/category.go
+
+### 次回課題（優先度順）
+1. `cart.go` をコミット（提案済みコミットメッセージあり）→ プルリク作成（`Closes #70` を含める）
+2. 残りハンドラの `RespondError` → `RespondWithError` 置換: `user.go`, `product.go`, `order.go`, `me.go`, `logout.go`, `refresh.go`, `auth/middleware.go`
+3. 統合テスト / 全テスト実行での回帰確認
+4. 全置換完了後に `slog` 導入とログ出力一元化（別 Issue）
+
+### コミットメッセージ例
+- `refactor(handler): replace RespondError with RespondWithError in cart.go`
+- `fix(apperror): guard reflect.TypeOf for nil in NewValidationError`

--- a/doc/memo/2026/04/2026-04-23_learning.md
+++ b/doc/memo/2026/04/2026-04-23_learning.md
@@ -1,0 +1,27 @@
+# 学習記録 2026-04-23
+作成日: 2026-04-23
+
+## セッション 1 (17:07)
+
+### 取り組んだタスク
+- ハンドラーのエラー処理を `apperror` 型に統一し、`respond.RespondWithError` を使う方針で統合
+- `NewValidationError` の nil ガード追加と `DeleteCategoryHandler` の変数名・レスポンス修正
+- ロジック層テストを `errors.As` ベースに変更し、統合テストでプレゼンテーションのメッセージを検証する方針を確立
+
+### ユーザーが質問した内容
+- ハンドラーのエラー処理を `apperror` 型に統一し、`respond.RespondWithError` を使うべきか
+- エラーメッセージの責務をコンストラクタで埋めるか `ToHTTP` メソッドで解決するか
+
+### 躓いたポイントと解決策
+- `NewValidationError` が `nil` を受けると `reflect.TypeOf(nil)` でパニックする
+  - 解決: `NewValidationError` に nil ガードを追加し、nil の場合は適切なエラーを返すようにした
+- `DeleteCategoryHandler` で誤った変数名 (`err` vs `respErr`) を使っていた
+  - 解決: 変数名を修正し、204 の応答を `c.JSON(..., nil)` ではなく `c.Status(204)` で返すように修正した
+- テストが `err.Error()` の部分文字列に依存しており、コンストラクタが `Message` を空にしていたため失敗した
+  - 解決: コンストラクタでのメッセージ責務を見直し、ロジック層テストは `errors.As` による型検査に切り替え、統合テストで表示メッセージを検証する方針にした
+
+### 次回課題
+- リポジトリ全体で残る `respond.RespondError` を `respond.RespondWithError` に置換する
+- `ValidationError.Rule` を `ToHTTP` のメッセージマッピングに活かす設計を検討する
+- `InternalError` に `Code/Reason` を追加する案を検討する
+- 変更をコミットして PR を作成する


### PR DESCRIPTION
close #70

### 概要
- 既存のエラーレスポンス用ヘルパー関数`respond.RespondError`のリファクタリング
- カスタムエラー構造体`apperror`型の7種類のエラーを利用した`respond.RespondWithError`への移行
- `apperror`を受け取り、HTTPステータスとメッセージ返却をハンドリングする`http.go`の作成、テスト
- メッセージ検証を行っていた一部テストコードの期待値をエラー型の検証に変更

### リファクタリング対象
#### middlware
 - middleware.go
#### handler
- cart.go
- category.go
- logout.go
- me.go
- order.go
- product.go
- refresh.go
- user.go

