### PR TITLE
Feat:セントラルエラーハンドラの実装

### DIFF
--- a/backend/auth/middleware.go
+++ b/backend/auth/middleware.go
@@ -8,7 +8,6 @@ import (
 
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/pkg/apperror"
-	"sol_coffeesys/backend/pkg/respond"
 
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
@@ -18,27 +17,28 @@ func AdminOnly(queries db.Querier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		tokenStr, err := tokenFromRequest(c)
 		if err != nil {
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
+
+			_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			c.Abort()
 			return
 		}
 		token, err := Validate(tokenStr)
 		if err != nil || token == nil || !token.Valid {
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			c.Abort()
 			return
 		}
 
 		claims, ok := token.Claims.(jwt.MapClaims)
 		if !ok {
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			c.Abort()
 			return
 		}
 
 		rawID, ok := claims["user.id"]
 		if !ok {
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			c.Abort()
 			return
 		}
@@ -50,7 +50,7 @@ func AdminOnly(queries db.Querier) gin.HandlerFunc {
 		case string:
 			id, perr := strconv.ParseInt(v, 10, 64)
 			if perr != nil {
-				respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
+				_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 				c.Abort()
 				return
 			}
@@ -60,17 +60,17 @@ func AdminOnly(queries db.Querier) gin.HandlerFunc {
 		user, err := queries.GetUserForUpdate(c.Request.Context(), userID)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
+				_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 				c.Abort()
 				return
 			}
-			respond.RespondWithError(c, apperror.NewInternalError("GetUserForUpdate", err, apperror.InternalServerMessageCommon))
+			_ = c.Error(apperror.NewInternalError("GetUserForUpdate", err, apperror.InternalServerMessageCommon))
 			c.Abort()
 			return
 		}
 
 		if user.Role != "admin" {
-			respond.RespondWithError(c, apperror.NewForbiddenError("admin", "user", apperror.ForbiddenMessageAdmin))
+			_ = c.Error(apperror.NewForbiddenError("admin", "user", apperror.ForbiddenMessageAdmin))
 			c.Abort()
 			return
 		}
@@ -85,28 +85,28 @@ func RequireAuth(queries db.Querier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		tokenStr, err := tokenFromRequest(c)
 		if err != nil {
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			c.Abort()
 			return
 		}
 
 		token, err := Validate(tokenStr)
 		if err != nil || token == nil || !token.Valid {
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			c.Abort()
 			return
 		}
 
 		claims, ok := token.Claims.(jwt.MapClaims)
 		if !ok {
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			c.Abort()
 			return
 		}
 
 		rawID, ok := claims["user.id"]
 		if !ok {
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			c.Abort()
 			return
 		}
@@ -124,13 +124,13 @@ func RequireAuth(queries db.Querier) gin.HandlerFunc {
 		case string:
 			id, perr := strconv.ParseInt(v, 10, 64)
 			if perr != nil {
-				respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
+				_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 				c.Abort()
 				return
 			}
 			userID = id
 		default:
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			c.Abort()
 			return
 		}
@@ -138,11 +138,11 @@ func RequireAuth(queries db.Querier) gin.HandlerFunc {
 		user, err := queries.GetUserForUpdate(c.Request.Context(), userID)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
+				_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 				c.Abort()
 				return
 			}
-			respond.RespondWithError(c, apperror.NewInternalError("GetUserForUpdate", err, apperror.InternalServerMessageCommon))
+			_ = c.Error(apperror.NewInternalError("GetUserForUpdate", err, apperror.InternalServerMessageCommon))
 			c.Abort()
 			return
 		}

--- a/backend/auth/middleware_test.go
+++ b/backend/auth/middleware_test.go
@@ -11,6 +11,8 @@ import (
 	"sol_coffeesys/backend/auth"
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/handler/testutil"
+	"sol_coffeesys/backend/middleware"
+	"sol_coffeesys/backend/pkg/apperror"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -267,6 +269,7 @@ func TestAdminOnly(t *testing.T) {
 	fq := &FakeQuerier{users: users}
 
 	router := gin.New()
+	router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 	router.GET("/admin", auth.AdminOnly(fq), func(c *gin.Context) {
 		c.Status(http.StatusNoContent)
 	})
@@ -412,6 +415,7 @@ func TestAdminOnly(t *testing.T) {
 			}
 
 			localRouter := gin.New()
+			localRouter.Use(middleware.ErrorHandler(apperror.ToHTTP))
 			if tt.name == "DB接続エラー" {
 				badQ := &BadQuerier{FakeQuerier: &FakeQuerier{users: map[int64]db.User{}}}
 				localRouter.GET("/admin", auth.AdminOnly(badQ), func(c *gin.Context) {
@@ -545,6 +549,7 @@ func TestRequireAuth(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			router := gin.New()
+			router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 			mockDB := new(testutil.MockDB)
 			if tt.setupMock != nil {
 				tt.setupMock(mockDB)

--- a/backend/handler/cart.go
+++ b/backend/handler/cart.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/pkg/apperror"
-	"sol_coffeesys/backend/pkg/respond"
 	"strconv"
 	"time"
 
@@ -16,7 +15,7 @@ func GetCartHandler(q db.Querier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		raw, exists := c.Get("userID")
 		if !exists {
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
@@ -29,13 +28,13 @@ func GetCartHandler(q db.Querier) gin.HandlerFunc {
 		case float64:
 			userID = int64(v)
 		default:
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
 		rows, err := q.ListCartItemsByUser(c.Request.Context(), userID)
 		if err != nil {
-			respond.RespondWithError(c, apperror.NewInternalError("ListCartItemsByUser", err, apperror.InternalServerMessageCommon))
+			_ = c.Error(apperror.NewInternalError("ListCartItemsByUser", err, apperror.InternalServerMessageCommon))
 			return
 		}
 
@@ -67,17 +66,17 @@ func AddToCartHandler(q db.Querier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		uid, ok := c.Get("userID")
 		if !ok {
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
 		var req addToCartRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
-			respond.RespondWithError(c, apperror.NewValidationError("request", nil, "", ""))
+			_ = c.Error(apperror.NewValidationError("request", nil, "", ""))
 			return
 		}
 		if req.Quantity <= 0 {
-			respond.RespondWithError(c, apperror.NewValidationError("qty", req.Quantity, "", ""))
+			_ = c.Error(apperror.NewValidationError("qty", req.Quantity, "", ""))
 			return
 		}
 
@@ -90,23 +89,23 @@ func AddToCartHandler(q db.Querier) gin.HandlerFunc {
 		case float64:
 			userID = int64(v)
 		default:
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
 		product, err := q.GetProduct(c.Request.Context(), req.ProductID)
 		if err != nil {
 			if err == sql.ErrNoRows {
-				respond.RespondWithError(c, apperror.NewNotFoundError("product", req.ProductID, ""))
+				_ = c.Error(apperror.NewNotFoundError("product", req.ProductID, ""))
 			} else {
-				respond.RespondWithError(c, apperror.NewInternalError("GetProduct", err, apperror.InternalServerMessageCommon))
+				_ = c.Error(apperror.NewInternalError("GetProduct", err, apperror.InternalServerMessageCommon))
 			}
 			return
 		}
 
 		cart, err := q.GetOrCreateCartForUser(c.Request.Context(), userID)
 		if err != nil {
-			respond.RespondWithError(c, apperror.NewInternalError("GetOrCreateCartForUser", err, apperror.InternalServerMessageCommon))
+			_ = c.Error(apperror.NewInternalError("GetOrCreateCartForUser", err, apperror.InternalServerMessageCommon))
 			return
 		}
 
@@ -117,7 +116,7 @@ func AddToCartHandler(q db.Querier) gin.HandlerFunc {
 			Price:     int64(product.Price),
 		})
 		if err != nil {
-			respond.RespondWithError(c, apperror.NewInternalError("AddCartItem", err, apperror.InternalServerMessageCommon))
+			_ = c.Error(apperror.NewInternalError("AddCartItem", err, apperror.InternalServerMessageCommon))
 			return
 		}
 
@@ -134,23 +133,23 @@ func UpdateCartItemHandler(q db.Querier) gin.HandlerFunc {
 		// URL pramの解析
 		id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 		if err != nil {
-			respond.RespondWithError(c, apperror.NewValidationError("id", id, "", ""))
+			_ = c.Error(apperror.NewValidationError("id", id, "", ""))
 			return
 		}
 
 		uid, ok := c.Get("userID")
 		if !ok {
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 		var req updateCartItemRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
-			respond.RespondWithError(c, apperror.NewValidationError("request", nil, "", ""))
+			_ = c.Error(apperror.NewValidationError("request", nil, "", ""))
 			return
 		}
 
 		if req.Quantity <= 0 {
-			respond.RespondWithError(c, apperror.NewValidationError("qty", req.Quantity, "", ""))
+			_ = c.Error(apperror.NewValidationError("qty", req.Quantity, "", ""))
 			return
 		}
 
@@ -163,7 +162,7 @@ func UpdateCartItemHandler(q db.Querier) gin.HandlerFunc {
 		case float64:
 			userID = int64(v)
 		default:
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
@@ -174,9 +173,9 @@ func UpdateCartItemHandler(q db.Querier) gin.HandlerFunc {
 		})
 		if err != nil {
 			if err == sql.ErrNoRows {
-				respond.RespondWithError(c, apperror.NewNotFoundError("cart_item", id, ""))
+				_ = c.Error(apperror.NewNotFoundError("cart_item", id, ""))
 			} else {
-				respond.RespondWithError(c, apperror.NewInternalError("UpdateCartItemQtyByUser", err, apperror.InternalServerMessageCommon))
+				_ = c.Error(apperror.NewInternalError("UpdateCartItemQtyByUser", err, apperror.InternalServerMessageCommon))
 			}
 			return
 		}
@@ -190,13 +189,13 @@ func RemoveCartItemHandler(q db.Querier) gin.HandlerFunc {
 
 		id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 		if err != nil {
-			respond.RespondWithError(c, apperror.NewValidationError("id", id, "", ""))
+			_ = c.Error(apperror.NewValidationError("id", id, "", ""))
 			return
 		}
 
 		uid, ok := c.Get("userID")
 		if !ok {
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 		var userID int64
@@ -208,16 +207,16 @@ func RemoveCartItemHandler(q db.Querier) gin.HandlerFunc {
 		case float64:
 			userID = int64(v)
 		default:
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
 		item, err := q.GetCartItemByID(c.Request.Context(), id)
 		if err != nil {
 			if err == sql.ErrNoRows {
-				respond.RespondWithError(c, apperror.NewNotFoundError("cart_item", id, ""))
+				_ = c.Error(apperror.NewNotFoundError("cart_item", id, ""))
 			} else {
-				respond.RespondWithError(c, apperror.NewInternalError("GetCartItemByID", err, apperror.InternalServerMessageCommon))
+				_ = c.Error(apperror.NewInternalError("GetCartItemByID", err, apperror.InternalServerMessageCommon))
 			}
 			return
 		}
@@ -225,15 +224,15 @@ func RemoveCartItemHandler(q db.Querier) gin.HandlerFunc {
 		cart, err := q.GetCartByUser(c.Request.Context(), userID)
 		if err != nil {
 			if err == sql.ErrNoRows {
-				respond.RespondWithError(c, apperror.NewNotFoundError("cart", userID, ""))
+				_ = c.Error(apperror.NewNotFoundError("cart", userID, ""))
 			} else {
-				respond.RespondWithError(c, apperror.NewInternalError("GetCartByUser", err, apperror.InternalServerMessageCommon))
+				_ = c.Error(apperror.NewInternalError("GetCartByUser", err, apperror.InternalServerMessageCommon))
 			}
 			return
 		}
 
 		if item.CartID != cart.ID {
-			respond.RespondWithError(c, apperror.NewNotFoundError("cart_item", id, ""))
+			_ = c.Error(apperror.NewNotFoundError("cart_item", id, ""))
 			return
 		}
 
@@ -241,7 +240,7 @@ func RemoveCartItemHandler(q db.Querier) gin.HandlerFunc {
 			ID:     id,
 			UserID: userID,
 		}); err != nil {
-			respond.RespondWithError(c, apperror.NewInternalError("RemoveCartItemByUser", err, apperror.InternalServerMessageCommon))
+			_ = c.Error(apperror.NewInternalError("RemoveCartItemByUser", err, apperror.InternalServerMessageCommon))
 			return
 		}
 
@@ -254,7 +253,7 @@ func ClearCartHandler(q db.Querier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		uid, ok := c.Get("userID")
 		if !ok {
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 		var userID int64
@@ -266,12 +265,12 @@ func ClearCartHandler(q db.Querier) gin.HandlerFunc {
 		case float64:
 			userID = int64(v)
 		default:
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
 		if err := q.ClearCartByUser(c.Request.Context(), userID); err != nil {
-			respond.RespondWithError(c, apperror.NewInternalError("ClearCartByUser", err, apperror.InternalServerMessageCommon))
+			_ = c.Error(apperror.NewInternalError("ClearCartByUser", err, apperror.InternalServerMessageCommon))
 			return
 		}
 

--- a/backend/handler/cart_test.go
+++ b/backend/handler/cart_test.go
@@ -10,6 +10,8 @@ import (
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/handler"
 	testutil "sol_coffeesys/backend/handler/testutil"
+	"sol_coffeesys/backend/middleware"
+	"sol_coffeesys/backend/pkg/apperror"
 	"testing"
 	"time"
 
@@ -178,6 +180,7 @@ func TestGetCartHandler(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			router := gin.New()
+			router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 			mockDB := new(testutil.MockDB)
 
 			if tt.setupMock != nil {
@@ -442,6 +445,7 @@ func TestAddToCartHandler(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			router := gin.New()
+			router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 			mockDB := new(testutil.MockDB)
 			if tt.setupMock != nil {
 				tt.setupMock(mockDB)
@@ -639,6 +643,7 @@ func TestUpdateCartItemHandler(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			router := gin.New()
+			router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 			mockDB := new(testutil.MockDB)
 			if tt.setupMock != nil {
 				tt.setupMock(mockDB)
@@ -902,6 +907,7 @@ func TestRemoveCartItemHandler(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			router := gin.New()
+			router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 			mockDB := new(testutil.MockDB)
 
 			if tt.setupMock != nil {
@@ -982,6 +988,7 @@ func TestClearCartHandler(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			router := gin.New()
+			router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 			mockDB := new(testutil.MockDB)
 			if tt.setupMock != nil {
 				tt.setupMock(mockDB)

--- a/backend/handler/category.go
+++ b/backend/handler/category.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/pkg/apperror"
-	"sol_coffeesys/backend/pkg/respond"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -28,12 +27,12 @@ func CreateCategoryHandler(queries db.Querier) gin.HandlerFunc {
 		var req CreateCategoryHandlerRequest
 
 		if err := c.ShouldBindJSON(&req); err != nil {
-			respond.RespondWithError(c, apperror.NewValidationError("request", nil, "", ""))
+			_ = c.Error(apperror.NewValidationError("request", nil, "", ""))
 			return
 		}
 
 		if req.Name == "" {
-			respond.RespondWithError(c, apperror.NewValidationError("category", nil, "", ""))
+			_ = c.Error(apperror.NewValidationError("category", nil, "", ""))
 			return
 		}
 
@@ -50,7 +49,7 @@ func CreateCategoryHandler(queries db.Querier) gin.HandlerFunc {
 			Description: description,
 		})
 		if err != nil {
-			respond.RespondWithError(c, apperror.NewInternalError("CreateCategory", err, apperror.InternalServerMessageCommon))
+			_ = c.Error(apperror.NewInternalError("CreateCategory", err, apperror.InternalServerMessageCommon))
 			return
 		}
 
@@ -78,18 +77,18 @@ func UpdateCategoryHandler(queries db.Querier) gin.HandlerFunc {
 
 		id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 		if err != nil {
-			respond.RespondWithError(c, apperror.NewValidationError("id", id, "", ""))
+			_ = c.Error(apperror.NewValidationError("id", id, "", ""))
 			return
 		}
 
 		var req UpdateCategoryHandlerRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
-			respond.RespondWithError(c, apperror.NewValidationError("request", nil, "", ""))
+			_ = c.Error(apperror.NewValidationError("request", nil, "bind", apperror.ValidationMessageRequest))
 			return
 		}
 
 		if req.Name == nil || *req.Name == "" {
-			respond.RespondWithError(c, apperror.NewValidationError("category", nil, "", ""))
+			_ = c.Error(apperror.NewValidationError("category", nil, "", ""))
 			return
 		}
 
@@ -108,9 +107,9 @@ func UpdateCategoryHandler(queries db.Querier) gin.HandlerFunc {
 		})
 		if err != nil {
 			if err == sql.ErrNoRows {
-				respond.RespondWithError(c, apperror.NewNotFoundError("category", id, ""))
+				_ = c.Error(apperror.NewNotFoundError("category", id, ""))
 			} else {
-				respond.RespondWithError(c, apperror.NewInternalError("UpdateCategory", err, apperror.InternalServerMessageCommon))
+				_ = c.Error(apperror.NewInternalError("UpdateCategory", err, apperror.InternalServerMessageCommon))
 			}
 			return
 		}
@@ -133,7 +132,7 @@ func GetCategoriesHandler(queries db.Querier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		categories, err := queries.ListCategories(c.Request.Context())
 		if err != nil {
-			respond.RespondWithError(c, apperror.NewInternalError("ListCategories", err, apperror.InternalServerMessageCommon))
+			_ = c.Error(apperror.NewInternalError("ListCategories", err, apperror.InternalServerMessageCommon))
 			return
 		}
 		resp := make([]CategoryResponse, 0, len(categories))
@@ -157,16 +156,16 @@ func DeleteCategoryHandler(queries db.Querier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 		if err != nil {
-			respond.RespondWithError(c, apperror.NewValidationError("id", id, "", ""))
+			_ = c.Error(apperror.NewValidationError("id", id, "", ""))
 			return
 		}
 
 		respErr := queries.DeleteCategory(c.Request.Context(), int64(id))
 		if respErr != nil {
 			if respErr == sql.ErrNoRows {
-				respond.RespondWithError(c, apperror.NewNotFoundError("category", id, ""))
+				_ = c.Error(apperror.NewNotFoundError("category", id, ""))
 			} else {
-				respond.RespondWithError(c, apperror.NewInternalError("DeleteCategory", respErr, apperror.InternalServerMessageCommon))
+				_ = c.Error(apperror.NewInternalError("DeleteCategory", respErr, apperror.InternalServerMessageCommon))
 			}
 			return
 		}

--- a/backend/handler/category_test.go
+++ b/backend/handler/category_test.go
@@ -11,6 +11,8 @@ import (
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/handler"
 	testutil "sol_coffeesys/backend/handler/testutil"
+	"sol_coffeesys/backend/middleware"
+	"sol_coffeesys/backend/pkg/apperror"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -137,6 +139,7 @@ func TestCreateCategoryHandler(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			gin.SetMode(gin.TestMode)
 			router := gin.Default()
+			router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 			mockDB := new(testutil.MockDB)
 			if tt.setupMock != nil {
 				tt.setupMock(mockDB)
@@ -303,6 +306,7 @@ func TestUpdateCategoryHandler(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			router := gin.Default()
+			router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 			mockDB := new(testutil.MockDB)
 
 			if tt.setupMock != nil {
@@ -378,6 +382,7 @@ func TestGetCategoriesHandler(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			gin.SetMode(gin.TestMode)
 			router := gin.Default()
+			router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 			mockDB := new(testutil.MockDB)
 			if tt.setupMock != nil {
 				tt.setupMock(mockDB)
@@ -459,6 +464,7 @@ func TestDeleteCategoryHandler(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			gin.SetMode(gin.TestMode)
 			router := gin.Default()
+			router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 			mockDB := new(testutil.MockDB)
 			if tt.setupMock != nil {
 				tt.setupMock(mockDB)

--- a/backend/handler/logout.go
+++ b/backend/handler/logout.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/pkg/apperror"
-	"sol_coffeesys/backend/pkg/respond"
 
 	"github.com/gin-gonic/gin"
 )
@@ -51,7 +50,7 @@ func LogoutHandler(queries db.Querier) gin.HandlerFunc {
 			if errors.Is(err, sql.ErrNoRows) {
 
 			} else {
-				respond.RespondWithError(c, apperror.NewInternalError("RevokeRefreshTokenByHash", err, apperror.InternalServerMessageCommon))
+				_ = c.Error(apperror.NewInternalError("RevokeRefreshTokenByHash", err, apperror.InternalServerMessageCommon))
 				c.Abort()
 				return
 			}

--- a/backend/handler/logout_test.go
+++ b/backend/handler/logout_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http/httptest"
 	"sol_coffeesys/backend/handler"
 	"sol_coffeesys/backend/handler/testutil"
+	"sol_coffeesys/backend/middleware"
+	"sol_coffeesys/backend/pkg/apperror"
 	"strings"
 	"testing"
 
@@ -19,6 +21,7 @@ import (
 func TestLogoutHandler_Success(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.Default()
+	router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 	mockDB := new(testutil.MockDB)
 
 	oldRefresh := strings.Repeat("a", 64)
@@ -105,6 +108,7 @@ func TestLogoutHandler_Errors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			router := gin.Default()
+			router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 			mockDB := new(testutil.MockDB)
 
 			if tt.setupMock != nil {

--- a/backend/handler/me.go
+++ b/backend/handler/me.go
@@ -6,7 +6,6 @@ import (
 	"sol_coffeesys/backend/auth"
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/pkg/apperror"
-	"sol_coffeesys/backend/pkg/respond"
 	"strconv"
 	"strings"
 
@@ -18,31 +17,31 @@ func MeHandler(q db.Querier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		authHeader := c.GetHeader("Authorization")
 		if authHeader == "" {
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("token_not_found", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("token_not_found", apperror.UnauthorizedMessageAuth))
 			return
 		}
 		parts := strings.SplitN(authHeader, " ", 2)
 		if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("invalid_format_token", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("invalid_format_token", apperror.UnauthorizedMessageAuth))
 			return
 		}
 		tokenStr := parts[1]
 
 		token, err := auth.Validate(tokenStr)
 		if err != nil || token == nil || !token.Valid {
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("invalid_token", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("invalid_token", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
 		claims, ok := token.Claims.(jwt.MapClaims)
 		if !ok {
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("failed_to_decode_token", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("failed_to_decode_token", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
 		rawID, ok := claims["user.id"]
 		if !ok {
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("userID_claims_not_found", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("userID_claims_not_found", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
@@ -53,21 +52,21 @@ func MeHandler(q db.Querier) gin.HandlerFunc {
 		case string:
 			id, perr := strconv.ParseInt(v, 10, 64)
 			if perr != nil {
-				respond.RespondWithError(c, apperror.NewUnauthorizedError("userID_parse_failed", apperror.UnauthorizedMessageAuth))
+				_ = c.Error(apperror.NewUnauthorizedError("userID_parse_failed", apperror.UnauthorizedMessageAuth))
 				return
 			}
 			userID = id
 		default:
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("userID_type_is_invalid", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("userID_type_is_invalid", apperror.UnauthorizedMessageAuth))
 			return
 		}
 		user, err := q.GetUserForUpdate(c.Request.Context(), userID)
 		if err != nil {
 			if err == sql.ErrNoRows {
-				respond.RespondWithError(c, apperror.NewUnauthorizedError("userID_is_not_authenticated", apperror.UnauthorizedMessageAuth))
+				_ = c.Error(apperror.NewUnauthorizedError("userID_is_not_authenticated", apperror.UnauthorizedMessageAuth))
 				return
 			}
-			respond.RespondWithError(c, apperror.NewInternalError("GetUserForUpdate", err, apperror.InternalServerMessageCommon))
+			_ = c.Error(apperror.NewInternalError("GetUserForUpdate", err, apperror.InternalServerMessageCommon))
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{

--- a/backend/handler/me_test.go
+++ b/backend/handler/me_test.go
@@ -9,6 +9,8 @@ import (
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/handler"
 	testutil "sol_coffeesys/backend/handler/testutil"
+	"sol_coffeesys/backend/middleware"
+	"sol_coffeesys/backend/pkg/apperror"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -224,6 +226,7 @@ func TestMeHandler(t *testing.T) {
 				auth.Validate = origValidate
 			}
 			router := gin.New()
+			router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 			mockDB := new(testutil.MockDB)
 			if tt.setupMock != nil {
 				tt.setupMock(mockDB)

--- a/backend/handler/order.go
+++ b/backend/handler/order.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/pkg/apperror"
-	"sol_coffeesys/backend/pkg/respond"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -98,7 +97,7 @@ func CreateOrderHandler(conn *sql.DB, queries *db.Queries) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		raw, exists := c.Get("userID")
 		if !exists {
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
@@ -111,13 +110,13 @@ func CreateOrderHandler(conn *sql.DB, queries *db.Queries) gin.HandlerFunc {
 		case float64:
 			userID = int64(v)
 		default:
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("userID_parse_failed", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("userID_parse_failed", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
 		tx, err := conn.BeginTx(c.Request.Context(), nil)
 		if err != nil {
-			respond.RespondWithError(c, apperror.NewInternalError("BeginTx", err, apperror.InternalServerMessageCommon))
+			_ = c.Error(apperror.NewInternalError("BeginTx", err, apperror.InternalServerMessageCommon))
 			return
 		}
 
@@ -132,16 +131,16 @@ func CreateOrderHandler(conn *sql.DB, queries *db.Queries) gin.HandlerFunc {
 			var be *apperror.BusinessLogicError
 
 			if errors.As(err, &ve) || errors.As(err, &ne) || errors.As(err, &ce) || errors.As(err, &be) {
-				respond.RespondWithError(c, err)
+				_ = c.Error(err)
 				return
 			}
 
-			respond.RespondWithError(c, apperror.NewInternalError("CreateOrder", err, apperror.InternalServerMessageCommon))
+			_ = c.Error(apperror.NewInternalError("CreateOrder", err, apperror.InternalServerMessageCommon))
 			return
 		}
 
 		if err := tx.Commit(); err != nil {
-			respond.RespondWithError(c, apperror.NewInternalError("Commit", err, apperror.InternalServerMessageCommon))
+			_ = c.Error(apperror.NewInternalError("Commit", err, apperror.InternalServerMessageCommon))
 			return
 		}
 		c.JSON(http.StatusCreated, gin.H{"order": order})
@@ -195,18 +194,18 @@ func CancelOrderHandler(conn *sql.DB, queries *db.Queries) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		orderIDParam := c.Param("id")
 		if orderIDParam == "" {
-			respond.RespondWithError(c, apperror.NewValidationError("order", nil, "", apperror.ValidationMessageEssentialOrder))
+			_ = c.Error(apperror.NewValidationError("order", nil, "", apperror.ValidationMessageEssentialOrder))
 			return
 		}
 		orderID, err := strconv.ParseInt(orderIDParam, 10, 64)
 		if err != nil {
-			respond.RespondWithError(c, apperror.NewValidationError("order", nil, "", apperror.ValidationMessageOrder))
+			_ = c.Error(apperror.NewValidationError("order", nil, "", apperror.ValidationMessageOrder))
 			return
 		}
 
 		raw, exists := c.Get("userID")
 		if !exists {
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
@@ -219,13 +218,13 @@ func CancelOrderHandler(conn *sql.DB, queries *db.Queries) gin.HandlerFunc {
 		case float64:
 			userID = int64(v)
 		default:
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
 		tx, err := conn.BeginTx(c.Request.Context(), nil)
 		if err != nil {
-			respond.RespondWithError(c, apperror.NewInternalError("BeginTx", err, apperror.InternalServerMessageCommon))
+			_ = c.Error(apperror.NewInternalError("BeginTx", err, apperror.InternalServerMessageCommon))
 			return
 		}
 
@@ -240,15 +239,15 @@ func CancelOrderHandler(conn *sql.DB, queries *db.Queries) gin.HandlerFunc {
 			var be *apperror.BusinessLogicError
 
 			if errors.As(err, &ve) || errors.As(err, &ne) || errors.As(err, &ce) || errors.As(err, &be) {
-				respond.RespondWithError(c, err)
+				_ = c.Error(err)
 				return
 			}
-			respond.RespondWithError(c, apperror.NewInternalError("CancelOrder", err, apperror.InternalServerMessageCommon))
+			_ = c.Error(apperror.NewInternalError("CancelOrder", err, apperror.InternalServerMessageCommon))
 			return
 		}
 
 		if err := tx.Commit(); err != nil {
-			respond.RespondWithError(c, apperror.NewInternalError("Commit", err, apperror.InternalServerMessageCommon))
+			_ = c.Error(apperror.NewInternalError("Commit", err, apperror.InternalServerMessageCommon))
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"order": updated})
@@ -296,7 +295,7 @@ func GetOrdersHandler(queries db.Querier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		raw, exists := c.Get("userID")
 		if !exists {
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
@@ -309,19 +308,19 @@ func GetOrdersHandler(queries db.Querier) gin.HandlerFunc {
 		case float64:
 			userID = int64(v)
 		default:
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
 		status := c.Query("status")
 		if !isValidOrderStatus(status) {
-			respond.RespondWithError(c, apperror.NewValidationError("status", status, "", ""))
+			_ = c.Error(apperror.NewValidationError("status", status, "", ""))
 			return
 		}
 
 		orders, err := getOrderLogic(c.Request.Context(), queries, userID)
 		if err != nil {
-			respond.RespondWithError(c, apperror.NewInternalError("GetOrders", err, apperror.InternalServerMessageCommon))
+			_ = c.Error(apperror.NewInternalError("GetOrders", err, apperror.InternalServerMessageCommon))
 			return
 		}
 

--- a/backend/handler/order_test.go
+++ b/backend/handler/order_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/handler/testutil"
+	"sol_coffeesys/backend/middleware"
 	"sol_coffeesys/backend/pkg/apperror"
 	"testing"
 	"time"
@@ -1200,6 +1201,7 @@ func TestGetOrdersHandler(t *testing.T) {
 			}
 
 			router := gin.New()
+			router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 			router.GET("/api/orders", func(c *gin.Context) {
 				if tt.userID != nil {
 					c.Set("userID", tt.userID)

--- a/backend/handler/product.go
+++ b/backend/handler/product.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/pkg/apperror"
-	"sol_coffeesys/backend/pkg/respond"
 	"strconv"
 	"time"
 
@@ -46,7 +45,7 @@ func ListProductsHandler(q db.Querier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		products, err := q.ListProducts(c.Request.Context())
 		if err != nil {
-			respond.RespondWithError(c, apperror.NewInternalError("ListProducts", err, apperror.InternalServerMessageCommon))
+			_ = c.Error(apperror.NewInternalError("ListProducts", err, apperror.InternalServerMessageCommon))
 			return
 		}
 		resp := make([]ProductResponse, 0, len(products))
@@ -82,16 +81,16 @@ func GetProductHandler(q db.Querier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 		if err != nil {
-			respond.RespondWithError(c, apperror.NewValidationError("id", id, "", ""))
+			_ = c.Error(apperror.NewValidationError("id", id, "", ""))
 			return
 		}
 
 		product, err := q.GetProduct(c.Request.Context(), int64(id))
 		if err != nil {
 			if err == sql.ErrNoRows {
-				respond.RespondWithError(c, apperror.NewNotFoundError("product", id, ""))
+				_ = c.Error(apperror.NewNotFoundError("product", id, ""))
 			} else {
-				respond.RespondWithError(c, apperror.NewInternalError("GetProduct", err, apperror.InternalServerMessageCommon))
+				_ = c.Error(apperror.NewInternalError("GetProduct", err, apperror.InternalServerMessageCommon))
 			}
 			return
 		}
@@ -124,33 +123,33 @@ func CreateProductHandler(q db.Querier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req CreateProductHandlerRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
-			respond.RespondWithError(c, apperror.NewValidationError("request", nil, "", ""))
+			_ = c.Error(apperror.NewValidationError("request", nil, "", ""))
 			return
 		}
 
 		if req.Name == "" {
-			respond.RespondWithError(c, apperror.NewValidationError("name", nil, "", ""))
+			_ = c.Error(apperror.NewValidationError("name", nil, "", ""))
 			return
 		}
 		if req.Price <= 0 {
-			respond.RespondWithError(c, apperror.NewValidationError("price", req.Price, "", ""))
+			_ = c.Error(apperror.NewValidationError("price", req.Price, "", ""))
 			return
 		}
 		if req.Sku == "" {
-			respond.RespondWithError(c, apperror.NewValidationError("sku", nil, "", ""))
+			_ = c.Error(apperror.NewValidationError("sku", nil, "", ""))
 			return
 		}
 
 		if len(req.Name) > 255 {
-			respond.RespondWithError(c, apperror.NewValidationError("", req.Name, "", apperror.ValidationMessageNameLength))
+			_ = c.Error(apperror.NewValidationError("", req.Name, "", apperror.ValidationMessageNameLength))
 			return
 		}
 
 		if _, err := q.GetCategory(c.Request.Context(), req.CategoryID); err != nil {
 			if err == sql.ErrNoRows {
-				respond.RespondWithError(c, apperror.NewNotFoundError("category", req.CategoryID, ""))
+				_ = c.Error(apperror.NewNotFoundError("category", req.CategoryID, ""))
 			} else {
-				respond.RespondWithError(c, apperror.NewInternalError("GetCategory", err, apperror.InternalServerMessageCommon))
+				_ = c.Error(apperror.NewInternalError("GetCategory", err, apperror.InternalServerMessageCommon))
 			}
 			return
 		}
@@ -177,10 +176,10 @@ func CreateProductHandler(q db.Querier) gin.HandlerFunc {
 		if err != nil {
 			var pqErr *pq.Error
 			if errors.As(err, &pqErr) && pqErr.Code == "23505" {
-				respond.RespondWithError(c, apperror.NewConflictError("sku", req.Sku, ""))
+				_ = c.Error(apperror.NewConflictError("sku", req.Sku, ""))
 				return
 			}
-			respond.RespondWithError(c, apperror.NewInternalError("CreateProduct", err, apperror.InternalServerMessageCommon))
+			_ = c.Error(apperror.NewInternalError("CreateProduct", err, apperror.InternalServerMessageCommon))
 			return
 		}
 
@@ -214,39 +213,39 @@ func UpdateProductHandler(q db.Querier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 		if err != nil {
-			respond.RespondWithError(c, apperror.NewValidationError("id", id, "", ""))
+			_ = c.Error(apperror.NewValidationError("id", id, "", ""))
 			return
 		}
 		var req UpdateProductHandlerRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
-			respond.RespondWithError(c, apperror.NewValidationError("request", nil, "", ""))
+			_ = c.Error(apperror.NewValidationError("request", nil, "", ""))
 			return
 		}
 
 		if req.Name == "" {
-			respond.RespondWithError(c, apperror.NewValidationError("name", nil, "", ""))
+			_ = c.Error(apperror.NewValidationError("name", nil, "", ""))
 			return
 		}
 		if req.Price <= 0 {
-			respond.RespondWithError(c, apperror.NewValidationError("price", req.Price, "", ""))
+			_ = c.Error(apperror.NewValidationError("price", req.Price, "", ""))
 			return
 		}
 		if req.Sku == "" {
-			respond.RespondWithError(c, apperror.NewValidationError("sku", nil, "", ""))
+			_ = c.Error(apperror.NewValidationError("sku", nil, "", ""))
 			return
 		}
 
 		if len(req.Name) > 255 {
-			respond.RespondWithError(c, apperror.NewValidationError("", req.Name, "", apperror.ValidationMessageNameLength))
+			_ = c.Error(apperror.NewValidationError("", req.Name, "", apperror.ValidationMessageNameLength))
 			return
 		}
 
 		// category 存在確認
 		if _, err := q.GetCategory(c.Request.Context(), req.CategoryID); err != nil {
 			if err == sql.ErrNoRows {
-				respond.RespondWithError(c, apperror.NewNotFoundError("category", req.CategoryID, ""))
+				_ = c.Error(apperror.NewNotFoundError("category", req.CategoryID, ""))
 			} else {
-				respond.RespondWithError(c, apperror.NewInternalError("GetCategory", err, apperror.InternalServerMessageCommon))
+				_ = c.Error(apperror.NewInternalError("GetCategory", err, apperror.InternalServerMessageCommon))
 			}
 			return
 		}
@@ -274,14 +273,14 @@ func UpdateProductHandler(q db.Querier) gin.HandlerFunc {
 		if err != nil {
 			var pqErr *pq.Error
 			if errors.As(err, &pqErr) && pqErr.Code == "23505" {
-				respond.RespondWithError(c, apperror.NewConflictError("sku", req.Sku, ""))
+				_ = c.Error(apperror.NewConflictError("sku", req.Sku, ""))
 				return
 			}
 
 			if err == sql.ErrNoRows {
-				respond.RespondWithError(c, apperror.NewNotFoundError("product", id, ""))
+				_ = c.Error(apperror.NewNotFoundError("product", id, ""))
 			} else {
-				respond.RespondWithError(c, apperror.NewInternalError("UpdateProduct", err, apperror.InternalServerMessageCommon))
+				_ = c.Error(apperror.NewInternalError("UpdateProduct", err, apperror.InternalServerMessageCommon))
 			}
 			return
 		}
@@ -316,15 +315,15 @@ func DeleteProductHandler(q db.Querier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 		if err != nil {
-			respond.RespondWithError(c, apperror.NewValidationError("id", id, "", ""))
+			_ = c.Error(apperror.NewValidationError("id", id, "", ""))
 			return
 		}
 		err = q.DeleteProduct(c.Request.Context(), int64(id))
 		if err != nil {
 			if err == sql.ErrNoRows {
-				respond.RespondWithError(c, apperror.NewNotFoundError("product", id, ""))
+				_ = c.Error(apperror.NewNotFoundError("product", id, ""))
 			} else {
-				respond.RespondWithError(c, apperror.NewInternalError("DeleteProduct", err, apperror.InternalServerMessageCommon))
+				_ = c.Error(apperror.NewInternalError("DeleteProduct", err, apperror.InternalServerMessageCommon))
 			}
 			return
 		}

--- a/backend/handler/product_test.go
+++ b/backend/handler/product_test.go
@@ -10,6 +10,8 @@ import (
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/handler"
 	testutil "sol_coffeesys/backend/handler/testutil"
+	"sol_coffeesys/backend/middleware"
+	"sol_coffeesys/backend/pkg/apperror"
 	"strings"
 	"testing"
 	"time"
@@ -23,6 +25,7 @@ import (
 func TestCreateProductHandler(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.Default()
+	router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 	mockDB := new(testutil.MockDB)
 
 	now := time.Now()
@@ -110,6 +113,7 @@ func TestProductCRUD_HappyPath(t *testing.T) {
 	// Create
 	{
 		router := gin.Default()
+		router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 		router.POST("/api/products", handler.CreateProductHandler(mockDB))
 		body := map[string]interface{}{
 			"name":           "Coffee",
@@ -132,6 +136,7 @@ func TestProductCRUD_HappyPath(t *testing.T) {
 	// Get
 	{
 		router := gin.Default()
+		router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 		router.GET("/api/products/:id", handler.GetProductHandler(mockDB))
 		req := httptest.NewRequest(http.MethodGet, "/api/products/1", nil)
 		w := httptest.NewRecorder()
@@ -142,6 +147,7 @@ func TestProductCRUD_HappyPath(t *testing.T) {
 	// List
 	{
 		router := gin.Default()
+		router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 		router.GET("/api/products", handler.ListProductsHandler(mockDB))
 		req := httptest.NewRequest(http.MethodGet, "/api/products", nil)
 		w := httptest.NewRecorder()
@@ -152,6 +158,7 @@ func TestProductCRUD_HappyPath(t *testing.T) {
 	// Update(PUT)
 	{
 		router := gin.Default()
+		router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 		router.PUT("/api/products/:id", handler.UpdateProductHandler(mockDB))
 		updateBody := map[string]interface{}{
 			"name":           "Coffee Updated",
@@ -174,6 +181,7 @@ func TestProductCRUD_HappyPath(t *testing.T) {
 	// Delete
 	{
 		router := gin.Default()
+		router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 		router.DELETE("/api/products/:id", handler.DeleteProductHandler(mockDB))
 		req := httptest.NewRequest(http.MethodDelete, "/api/products/1", nil)
 		w := httptest.NewRecorder()
@@ -199,6 +207,7 @@ func TestCreateProduct_ValidationTable(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			router := gin.Default()
+			router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 			mockDB := new(testutil.MockDB)
 			router.POST("/api/products", handler.CreateProductHandler(mockDB))
 			var b []byte
@@ -220,6 +229,7 @@ func TestCreateProduct_ValidationTable(t *testing.T) {
 func TestCreateProduct_CategoryNotFound(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.Default()
+	router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 	mockDB := new(testutil.MockDB)
 
 	mockDB.On("GetCategory", mock.Anything, int64(1)).Return(db.Category{}, sql.ErrNoRows)
@@ -253,6 +263,7 @@ func TestCreateProduct_CategoryNotFound(t *testing.T) {
 func TestUpdateProduct_CategoryNotFound(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.Default()
+	router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 	mockDB := new(testutil.MockDB)
 
 	mockDB.On("GetCategory", mock.Anything, int64(1)).Return(db.Category{}, sql.ErrNoRows)
@@ -283,6 +294,7 @@ func TestUpdateProduct_CategoryNotFound(t *testing.T) {
 func TestUpdateProduct_NotFound(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.Default()
+	router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 	mockDB := new(testutil.MockDB)
 
 	mockDB.On("GetCategory", mock.Anything, int64(1)).Return(db.Category{
@@ -319,6 +331,7 @@ func TestUpdateProduct_NotFound(t *testing.T) {
 func TestGetProduct_NotFound(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.Default()
+	router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 	mockDB := new(testutil.MockDB)
 
 	mockDB.On("GetProduct", mock.Anything, int64(999)).Return(db.Product{}, sql.ErrNoRows)
@@ -337,6 +350,7 @@ func TestGetProduct_NotFound(t *testing.T) {
 func TestDeleteProduct_NotFound(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.Default()
+	router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 	mockDB := new(testutil.MockDB)
 
 	mockDB.On("DeleteProduct", mock.Anything, int64(999)).Return(sql.ErrNoRows)
@@ -370,6 +384,7 @@ func TestUpdateProducts_ValidationTable(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			router := gin.Default()
+			router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 			mockDB := new(testutil.MockDB)
 			router.PUT("/api/products/:id", handler.UpdateProductHandler(mockDB))
 			var b []byte
@@ -391,6 +406,7 @@ func TestUpdateProducts_ValidationTable(t *testing.T) {
 func TestGetProduct_InvalidID(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.Default()
+	router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 	mockDB := new(testutil.MockDB)
 	router.GET("/api/products/:id", handler.GetProductHandler(mockDB))
 
@@ -407,6 +423,7 @@ func TestGetProduct_InvalidID(t *testing.T) {
 func TestUpdateProduct_InvalidID(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.Default()
+	router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 	mockDB := new(testutil.MockDB)
 
 	router.PUT("/api/products/:id", handler.UpdateProductHandler(mockDB))
@@ -437,6 +454,7 @@ func TestUpdateProduct_InvalidID(t *testing.T) {
 func TestDeleteProduct_InvalidID(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.Default()
+	router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 	mockDB := new(testutil.MockDB)
 
 	router.DELETE("/api/products/:id", handler.DeleteProductHandler(mockDB))
@@ -455,6 +473,7 @@ func TestDeleteProduct_InvalidID(t *testing.T) {
 func TestCreateProduct_SkuConflict_409(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.Default()
+	router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 	mockDB := new(testutil.MockDB)
 
 	mockDB.On("GetCategory", mock.Anything, int64(1)).Return(db.Category{
@@ -488,6 +507,7 @@ func TestCreateProduct_SkuConflict_409(t *testing.T) {
 func TestUpdateProduct_SkuConflict_409(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.Default()
+	router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 	mockDB := new(testutil.MockDB)
 
 	mockDB.On("GetCategory", mock.Anything, int64(1)).Return(db.Category{
@@ -526,6 +546,7 @@ func TestProductAuth_AdminOnly_Routes(t *testing.T) {
 	mockDB := new(testutil.MockDB)
 
 	router := gin.Default()
+	router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 	router.POST("/api/products", auth.AdminOnly(mockDB), handler.CreateProductHandler(mockDB))
 
 	// 1)認証なし=>401

--- a/backend/handler/refresh.go
+++ b/backend/handler/refresh.go
@@ -9,7 +9,6 @@ import (
 	"sol_coffeesys/backend/auth"
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/pkg/apperror"
-	"sol_coffeesys/backend/pkg/respond"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -19,7 +18,7 @@ func RefreshTokenHandler(q db.Querier, tokenGenerator auth.TokenGenerator) gin.H
 	return func(c *gin.Context) {
 		cookie, err := c.Request.Cookie("refresh_token")
 		if err != nil {
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("invalid_refresh_token", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("invalid_refresh_token", apperror.UnauthorizedMessageAuth))
 			return
 		}
 		sum := sha256.Sum256([]byte(cookie.Value))
@@ -28,16 +27,16 @@ func RefreshTokenHandler(q db.Querier, tokenGenerator auth.TokenGenerator) gin.H
 		rt, err := q.GetRefreshTokenByHash(c.Request.Context(), hash)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				respond.RespondWithError(c, apperror.NewUnauthorizedError("token_not_found", apperror.UnauthorizedMessageAuth))
+				_ = c.Error(apperror.NewUnauthorizedError("token_not_found", apperror.UnauthorizedMessageAuth))
 			} else {
-				respond.RespondWithError(c, apperror.NewInternalError("GetRefreshTokenByHash", err, apperror.InternalServerMessageCommon))
+				_ = c.Error(apperror.NewInternalError("GetRefreshTokenByHash", err, apperror.InternalServerMessageCommon))
 			}
 			c.Abort()
 			return
 		}
 
 		if rt.RevokedAt.Valid || rt.ExpiresAt.Before(time.Now()) {
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("refresh_token_revoked_alredy", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("refresh_token_revoked_alredy", apperror.UnauthorizedMessageAuth))
 			c.Abort()
 			return
 		}
@@ -45,9 +44,9 @@ func RefreshTokenHandler(q db.Querier, tokenGenerator auth.TokenGenerator) gin.H
 		user, err := q.GetUserByID(c.Request.Context(), rt.UserID)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				respond.RespondWithError(c, apperror.NewUnauthorizedError("token_not_found", apperror.UnauthorizedMessageAuth))
+				_ = c.Error(apperror.NewUnauthorizedError("token_not_found", apperror.UnauthorizedMessageAuth))
 			} else {
-				respond.RespondWithError(c, apperror.NewInternalError("GetUserByID", err, apperror.InternalServerMessageCommon))
+				_ = c.Error(apperror.NewInternalError("GetUserByID", err, apperror.InternalServerMessageCommon))
 			}
 			c.Abort()
 			return
@@ -55,7 +54,7 @@ func RefreshTokenHandler(q db.Querier, tokenGenerator auth.TokenGenerator) gin.H
 
 		newRefresh, _, expiresAt, err := GenerateRefreshToken(c.Request.Context(), q, user.ID)
 		if err != nil {
-			respond.RespondWithError(c, apperror.NewInternalError("GenerateRefreshToken", err, apperror.InternalServerMessageRefresh))
+			_ = c.Error(apperror.NewInternalError("GenerateRefreshToken", err, apperror.InternalServerMessageRefresh))
 			c.Abort()
 			return
 		}
@@ -64,7 +63,7 @@ func RefreshTokenHandler(q db.Querier, tokenGenerator auth.TokenGenerator) gin.H
 			if errors.Is(err, sql.ErrNoRows) {
 				// 存在しないトークンは無視
 			} else {
-				respond.RespondWithError(c, apperror.NewInternalError("RevokeRefreshByRaw", err, apperror.InternalServerMessageCommon))
+				_ = c.Error(apperror.NewInternalError("RevokeRefreshByRaw", err, apperror.InternalServerMessageCommon))
 				c.Abort()
 				return
 			}
@@ -72,7 +71,7 @@ func RefreshTokenHandler(q db.Querier, tokenGenerator auth.TokenGenerator) gin.H
 
 		accessToken, err := tokenGenerator.GenerateToken(user.ID)
 		if err != nil {
-			respond.RespondWithError(c, apperror.NewInternalError("GenerateToken", err, apperror.InternalServerMessageGenToken))
+			_ = c.Error(apperror.NewInternalError("GenerateToken", err, apperror.InternalServerMessageGenToken))
 			c.Abort()
 			return
 		}
@@ -152,7 +151,7 @@ func RevokeRefreshHandler(q db.Querier) gin.HandlerFunc {
 			if errors.Is(err, sql.ErrNoRows) {
 
 			} else {
-				respond.RespondWithError(c, apperror.NewInternalError("RevokeRefreshByRaw", err, apperror.InternalServerMessageCommon))
+				_ = c.Error(apperror.NewInternalError("RevokeRefreshByRaw", err, apperror.InternalServerMessageCommon))
 				c.Abort()
 				return
 			}

--- a/backend/handler/refresh_test.go
+++ b/backend/handler/refresh_test.go
@@ -10,6 +10,8 @@ import (
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/handler"
 	"sol_coffeesys/backend/handler/testutil"
+	"sol_coffeesys/backend/middleware"
+	"sol_coffeesys/backend/pkg/apperror"
 	"strings"
 	"testing"
 	"time"
@@ -23,6 +25,7 @@ func TestRefreshTokenHandler_Success(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	router := gin.Default()
+	router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 	mockDB := new(testutil.MockDB)
 	mockTG := new(MockTokenGenerator)
 
@@ -243,6 +246,7 @@ func TestRefreshTokenHandler_Errros(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			router := gin.Default()
+			router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 			mockDB := new(testutil.MockDB)
 			mockTG := new(MockTokenGenerator)
 
@@ -276,6 +280,7 @@ func TestRefreshTokenHandler_Errros(t *testing.T) {
 func TestRevokeRefreshHandler_Success(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.Default()
+	router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 	mockDB := new(testutil.MockDB)
 
 	oldRefresh := strings.Repeat("a", 64)
@@ -324,6 +329,7 @@ func TestRevokeRefreshHandler_Success(t *testing.T) {
 func TestRevokeRefreshHandler_DBError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.Default()
+	router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 	mockDB := new(testutil.MockDB)
 
 	oldRefresh := strings.Repeat("a", 64)

--- a/backend/handler/user.go
+++ b/backend/handler/user.go
@@ -7,7 +7,6 @@ import (
 	"sol_coffeesys/backend/auth"
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/pkg/apperror"
-	"sol_coffeesys/backend/pkg/respond"
 	"sol_coffeesys/backend/pkg/validation"
 	"strconv"
 	"time"
@@ -41,21 +40,21 @@ func RegisterUserHandler(q db.Querier) gin.HandlerFunc {
 
 		if err := c.ShouldBindJSON(&req); err != nil {
 			c.Error(err)
-			respond.RespondWithError(c, apperror.NewValidationError("request", nil, "bind", apperror.ValidationMessageRequest))
+			_ = c.Error(apperror.NewValidationError("request", nil, "bind", apperror.ValidationMessageRequest))
 			return
 		}
 		// バリデーションチェック
 		if err := validation.ValidateRegisterRequest(req.Name, req.Email, req.Password); err != nil {
 			switch {
 			case errors.Is(err, validation.ErrInvalidName):
-				respond.RespondWithError(c, apperror.NewValidationError("name", nil, "", ""))
+				_ = c.Error(apperror.NewValidationError("name", nil, "", ""))
 			case errors.Is(err, validation.ErrInvalidEmail):
-				respond.RespondWithError(c, apperror.NewValidationError("email", nil, "", ""))
+				_ = c.Error(apperror.NewValidationError("email", nil, "", ""))
 			case errors.Is(err, validation.ErrInvalidPassword):
-				respond.RespondWithError(c, apperror.NewValidationError("password", nil, "", ""))
+				_ = c.Error(apperror.NewValidationError("password", nil, "", ""))
 			default:
 				c.Error(err)
-				respond.RespondWithError(c, apperror.NewValidationError("request", nil, "", ""))
+				_ = c.Error(apperror.NewValidationError("request", nil, "", ""))
 			}
 			return
 		}
@@ -63,7 +62,7 @@ func RegisterUserHandler(q db.Querier) gin.HandlerFunc {
 		hashed, err := HashPassword(req.Password)
 		if err != nil {
 			c.Error(err)
-			respond.RespondWithError(c, err)
+			_ = c.Error(err)
 			return
 		}
 
@@ -77,11 +76,11 @@ func RegisterUserHandler(q db.Querier) gin.HandlerFunc {
 			var pqErr *pq.Error
 			if errors.As(err, &pqErr) {
 				if pqErr.Code == "23505" {
-					respond.RespondWithError(c, apperror.NewValidationError("email", req.Email, "", apperror.ValidationMessageConflictedEmail))
+					_ = c.Error(apperror.NewValidationError("email", req.Email, "", apperror.ValidationMessageConflictedEmail))
 					return
 				}
 			}
-			respond.RespondWithError(c, apperror.NewInternalError("CreateUser", err, apperror.InternalServerMessageCommon))
+			_ = c.Error(apperror.NewInternalError("CreateUser", err, apperror.InternalServerMessageCommon))
 			return
 		}
 
@@ -101,41 +100,41 @@ func LoginUserHandler(q db.Querier, tokenGenerator auth.TokenGenerator) gin.Hand
 		var req LoginRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
 			c.Error(err)
-			respond.RespondWithError(c, apperror.NewValidationError("request", nil, "bind", apperror.ValidationMessageRequest))
+			_ = c.Error(apperror.NewValidationError("request", nil, "bind", apperror.ValidationMessageRequest))
 			return
 		}
 
 		// バリデーションチェック
 		if err := validation.ValidateEmail(req.Email); err != nil {
-			respond.RespondWithError(c, apperror.NewValidationError("email", nil, "", ""))
+			_ = c.Error(apperror.NewValidationError("email", nil, "", ""))
 			return
 		}
 		if err := validation.ValidatePassword(req.Password); err != nil {
-			respond.RespondWithError(c, apperror.NewValidationError("password", nil, "", ""))
+			_ = c.Error(apperror.NewValidationError("password", nil, "", ""))
 			return
 		}
 
 		user, err := q.GetUserByEmail(c.Request.Context(), req.Email)
 		if err != nil {
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageEmailOrPassword))
+			_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageEmailOrPassword))
 			return
 		}
 		err = bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(req.Password))
 		if err != nil {
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageEmailOrPassword))
+			_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageEmailOrPassword))
 			return
 		}
 
 		token, err := tokenGenerator.GenerateToken(user.ID)
 		// token, err := auth.GenerateToken(int32(user.ID))
 		if err != nil {
-			respond.RespondWithError(c, apperror.NewInternalError("GenerateToken", err, apperror.InternalServerMessageGenToken))
+			_ = c.Error(apperror.NewInternalError("GenerateToken", err, apperror.InternalServerMessageGenToken))
 			return
 		}
 
 		refreshToken, _, expiresAt, err := GenerateRefreshToken(c.Request.Context(), q, user.ID)
 		if err != nil {
-			respond.RespondWithError(c, apperror.NewInternalError("GenerateRefreshToken", err, apperror.InternalServerMessageRefresh))
+			_ = c.Error(apperror.NewInternalError("GenerateRefreshToken", err, apperror.InternalServerMessageRefresh))
 			return
 		}
 
@@ -190,29 +189,29 @@ func SetUserRoleHandler(q db.Querier) gin.HandlerFunc {
 		idStr := c.Param("id")
 		userID, err := strconv.ParseInt(idStr, 10, 64)
 		if err != nil {
-			respond.RespondWithError(c, apperror.NewValidationError("id", nil, "", ""))
+			_ = c.Error(apperror.NewValidationError("id", nil, "", ""))
 			return
 		}
 		raw, exists := c.Get("userID")
 		if !exists {
-			respond.RespondWithError(c, apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
+			_ = c.Error(apperror.NewUnauthorizedError("", apperror.UnauthorizedMessageAuth))
 			return
 		}
 		adminID := raw.(int64)
 
 		if adminID == userID {
-			respond.RespondWithError(c, apperror.NewBusinessLogicError(apperror.BusinessLogicMessageRole))
+			_ = c.Error(apperror.NewBusinessLogicError(apperror.BusinessLogicMessageRole))
 			return
 		}
 
 		var req SetUserRoleRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
-			respond.RespondWithError(c, apperror.NewValidationError("request", nil, "bind", apperror.ValidationMessageRequest))
+			_ = c.Error(apperror.NewValidationError("request", nil, "bind", apperror.ValidationMessageRequest))
 			return
 		}
 
 		if err := validation.ValidateRole(req.Role); err != nil {
-			respond.RespondWithError(c, apperror.NewValidationError("role", nil, "", ""))
+			_ = c.Error(apperror.NewValidationError("role", nil, "", ""))
 			return
 		}
 
@@ -222,10 +221,10 @@ func SetUserRoleHandler(q db.Querier) gin.HandlerFunc {
 		})
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				respond.RespondWithError(c, apperror.NewNotFoundError("user", userID, ""))
+				_ = c.Error(apperror.NewNotFoundError("user", userID, ""))
 				return
 			}
-			respond.RespondWithError(c, apperror.NewInternalError("UpdateUserRole", err, apperror.InternalServerMessageCommon))
+			_ = c.Error(apperror.NewInternalError("UpdateUserRole", err, apperror.InternalServerMessageCommon))
 			return
 		}
 		c.JSON(http.StatusOK, user)

--- a/backend/handler/user_test.go
+++ b/backend/handler/user_test.go
@@ -13,6 +13,8 @@ import (
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/handler"
 	testutil "sol_coffeesys/backend/handler/testutil"
+	"sol_coffeesys/backend/middleware"
+	"sol_coffeesys/backend/pkg/apperror"
 	"strings"
 	"testing"
 	"time"
@@ -219,6 +221,7 @@ func TestLoginUserHandler(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			gin.SetMode(gin.TestMode)
 			router := gin.Default()
+			router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 			mockDB := new(testutil.MockDB)
 			mockTokenGenerator := new(MockTokenGenerator)
 
@@ -458,6 +461,7 @@ func TestSetUserRoleHandler(t *testing.T) {
 			}
 
 			router := gin.New()
+			router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 			router.PATCH("/admin/users/:id/role", auth.AdminOnly(mockDB), handler.SetUserRoleHandler(mockDB))
 
 			body, _ := json.Marshal(tt.requestBody)
@@ -666,6 +670,7 @@ func TestRegisterUserHandler(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			gin.SetMode(gin.TestMode)
 			router := gin.Default()
+			router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 			mockDB := new(testutil.MockDB)
 			if tt.setupMock != nil {
 				tt.setupMock(mockDB)
@@ -724,6 +729,7 @@ func TestHashPassword(t *testing.T) {
 func TestLoginUserHandler_SetsCookies(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.Default()
+	router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 	mockDB := new(testutil.MockDB)
 	mockTokenGenerator := new(MockTokenGenerator)
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"os"
 	"sol_coffeesys/backend/db"
+	"sol_coffeesys/backend/middleware"
+	"sol_coffeesys/backend/pkg/apperror"
 	"sol_coffeesys/backend/routes"
 
 	"github.com/gin-contrib/cors"
@@ -38,6 +40,9 @@ func main() {
 		AllowHeaders:     []string{"Origin", "Content-Type", "Accept", "Authorization"},
 		AllowCredentials: true,
 	}))
+
+	// エラーハンドラ
+	r.Use(middleware.ErrorHandler(apperror.ToHTTP))
 
 	//4. ルーティング設定
 	routes.SetupRoutes(r, conn, queries)

--- a/backend/middleware/error_handler.go
+++ b/backend/middleware/error_handler.go
@@ -1,0 +1,32 @@
+package middleware
+
+import (
+	"sol_coffeesys/backend/pkg/respond"
+
+	"github.com/gin-gonic/gin"
+)
+
+type ErrorResponder interface {
+	ToHTTP(err error) (int, string)
+}
+
+func ErrorHandler(toHTTP func(error) (int, string)) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Next()
+
+		if len(c.Errors) == 0 || c.Writer.Written() {
+			return
+		}
+
+		err := c.Errors.Last().Err
+		if err == nil {
+			return
+		}
+
+		respond.RespondWithError(c, err)
+
+		// status, msg := toHTTP(err)
+		// c.JSON(status, gin.H{"error": msg})
+
+	}
+}

--- a/backend/middleware/error_handler_test.go
+++ b/backend/middleware/error_handler_test.go
@@ -1,0 +1,94 @@
+package middleware_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sol_coffeesys/backend/middleware"
+	"sol_coffeesys/backend/pkg/apperror"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestErrorHandler(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name       string
+		handler    gin.HandlerFunc
+		wantStatus int
+		wantBody   map[string]any
+	}{
+		{
+			name: "ValidationErrorは400を返す",
+			handler: func(c *gin.Context) {
+				_ = c.Error(apperror.NewValidationError("email", "bad-email", "format", ""))
+			},
+			wantStatus: http.StatusBadRequest,
+			wantBody: map[string]any{
+				"error": apperror.ValidationMessageEmail,
+			},
+		},
+		{
+			name: "UnauthorizedErrorは401を返す",
+			handler: func(c *gin.Context) {
+				_ = c.Error(apperror.NewUnauthorizedError("token_not_found", apperror.UnauthorizedMessageAuth))
+			},
+			wantStatus: http.StatusUnauthorized,
+			wantBody: map[string]any{
+				"error": apperror.UnauthorizedMessageAuth,
+			},
+		},
+		{
+			name: "エラーなしは下流レスポンス維持",
+			handler: func(c *gin.Context) {
+				c.JSON(http.StatusOK, gin.H{"ok": true})
+			},
+			wantStatus: http.StatusOK,
+			wantBody: map[string]any{
+				"ok": true,
+			},
+		},
+		{
+			name: "既に書き込み済みなら上書きしない",
+			handler: func(c *gin.Context) {
+				c.JSON(http.StatusTeapot, gin.H{"before": "written"})
+				_ = c.Error(apperror.NewInternalError("X", nil, apperror.InternalServerMessageCommon))
+			},
+			wantStatus: http.StatusTeapot,
+			wantBody: map[string]any{
+				"before": "written",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := gin.New()
+			r.Use(middleware.ErrorHandler(apperror.ToHTTP))
+			r.GET("/test", tt.handler)
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			var got map[string]any
+			if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+				t.Fatalf("failed to unmarshal body: %v body=%s", err, w.Body.String())
+			}
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("status mismatch: got=%d want=%d body=%s", w.Code, tt.wantStatus, w.Body.String())
+			}
+
+			if !reflect.DeepEqual(got, tt.wantBody) {
+				t.Fatalf("body mismatch: got=%v want=%v", got, tt.wantBody)
+			}
+		})
+	}
+}

--- a/backend/routes/routes_test.go
+++ b/backend/routes/routes_test.go
@@ -10,6 +10,8 @@ import (
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/handler"
 	testutil "sol_coffeesys/backend/handler/testutil"
+	"sol_coffeesys/backend/middleware"
+	"sol_coffeesys/backend/pkg/apperror"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -59,6 +61,7 @@ func TestCategories_AdminOnlyMiddleware(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			router := gin.Default()
+			router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 			mockDB := new(testutil.MockDB)
 			if tt.setupMock != nil {
 				tt.setupMock(mockDB)
@@ -119,6 +122,7 @@ func TestCartRoutes_AuthMiddlewareAndDeleteIdempotency(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			router := gin.Default()
+			router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 			mockDB := new(testutil.MockDB)
 			if tt.setupMock != nil {
 				tt.setupMock(mockDB)

--- a/backend/tests/cart_integration_test.go
+++ b/backend/tests/cart_integration_test.go
@@ -9,6 +9,8 @@ import (
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/handler"
 	testutil "sol_coffeesys/backend/handler/testutil"
+	"sol_coffeesys/backend/middleware"
+	"sol_coffeesys/backend/pkg/apperror"
 	"testing"
 	"time"
 
@@ -153,6 +155,7 @@ func TestCartFlow_TableTopCases(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			router := gin.New()
+			router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 			mockDB := new(testutil.MockDB)
 			if tc.setupMock != nil {
 				tc.setupMock(mockDB)

--- a/backend/tests/category_integration_test.go
+++ b/backend/tests/category_integration_test.go
@@ -11,6 +11,8 @@ import (
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/handler"
 	"sol_coffeesys/backend/handler/testutil"
+	"sol_coffeesys/backend/middleware"
+	"sol_coffeesys/backend/pkg/apperror"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -131,6 +133,7 @@ func TestCreateCategory_AdminAndNonAdmin(t *testing.T) {
 			}
 
 			router := gin.New()
+			router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 			router.POST("/api/categories", auth.AdminOnly(mockDB), handler.CreateCategoryHandler(mockDB))
 			router.PUT("/api/categories/:id", auth.AdminOnly(mockDB), handler.UpdateCategoryHandler(mockDB))
 			router.DELETE("/api/categories/:id", auth.AdminOnly(mockDB), handler.DeleteCategoryHandler(mockDB))

--- a/backend/tests/order_concurrency_test.go
+++ b/backend/tests/order_concurrency_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http/httptest"
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/handler"
+	"sol_coffeesys/backend/middleware"
+	"sol_coffeesys/backend/pkg/apperror"
 	"sync"
 	"testing"
 
@@ -119,6 +121,7 @@ func TestCreateOrderHandler_Concurrency(t *testing.T) {
 					<-ready
 
 					router := gin.New()
+					router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 					router.POST("/api/orders", func(c *gin.Context) {
 						c.Set("userID", userID)
 						handler.CreateOrderHandler(testDB, queries)(c)

--- a/backend/tests/order_integration_test.go
+++ b/backend/tests/order_integration_test.go
@@ -15,6 +15,8 @@ import (
 	"path/filepath"
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/handler"
+	"sol_coffeesys/backend/middleware"
+	"sol_coffeesys/backend/pkg/apperror"
 	"testing"
 	"time"
 
@@ -172,6 +174,7 @@ func TestCreateOrderHandler_HappyPath(t *testing.T) {
 	userID, productID := seedCreateOrderHappyPath(t)
 
 	router := gin.New()
+	router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 	queries := db.New(testDB)
 	router.POST("/api/orders", func(c *gin.Context) {
 		c.Set("userID", userID)
@@ -366,6 +369,7 @@ func TestCreateOrderHandler(t *testing.T) {
 			}
 
 			router := gin.New()
+			router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 			queries := db.New(testDB)
 
 			router.POST("/api/orders", func(c *gin.Context) {
@@ -458,6 +462,7 @@ func TestCancelOrderHandler_HappyPath(t *testing.T) {
 	userID, orderID, productID := seedCancelOrderHappyPath(t)
 
 	router := gin.New()
+	router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 	queries := db.New(testDB)
 
 	router.POST("/api/orders/:id/cancel", func(c *gin.Context) {
@@ -822,6 +827,7 @@ func TestCancelOrderHandler(t *testing.T) {
 			}
 
 			router := gin.New()
+			router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 			queries := db.New(testDB)
 
 			router.POST("/api/orders/:id/cancel", func(c *gin.Context) {


### PR DESCRIPTION
close #72

### 概要
- エラーレスポンスをミドルウェアで一元的に処理するため、`ErrorHandler` を追加
- 各ハンドラではエラー発生時に `c.Error()` でエラーをコンテキストへ積み、レスポンス生成はミドルウェアに委譲
- `main.go` で `router.Use(middleware.ErrorHandler(apperror.ToHTTP))` を設定し、HTTP ステータスとエラーメッセージの生成を共通化

### 変更内容
- 既存ハンドラのエラー処理を `c.Error()` ベースへ移行
- テスト側のルーターにも `ErrorHandler` を追加し、異常系レスポンスを従来どおり検証できるように調整
- エラー変換は `apperror.ToHTTP` に集約し、レスポンス生成の責務をミドルウェアへ統一

### 確認
- `go test ./...` で全テスト通過