### PR TITLE
Feature:request_id発行ミドルウェアの実装

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -33,6 +33,10 @@ func main() {
 	//3. Ginルーター初期化
 	r := gin.Default()
 
+	// 4. ミドルウェア設定
+	// request_id生成
+	r.Use(middleware.RequestIDMiddleware())
+
 	// CORS設定:Next.jsだけに絞る
 	r.Use(cors.New(cors.Config{
 		AllowOrigins:     []string{"http://localhost:3000"},
@@ -44,10 +48,10 @@ func main() {
 	// エラーハンドラ
 	r.Use(middleware.ErrorHandler(apperror.ToHTTP))
 
-	//4. ルーティング設定
+	//5. ルーティング設定
 	routes.SetupRoutes(r, conn, queries)
 
-	//5. サーバー起動
+	//6. サーバー起動
 	log.Println("Server starting on :8080...")
 	if err := r.Run(":8080"); err != nil {
 		log.Fatal("failed to run server:", err)

--- a/backend/middleware/request_id.go
+++ b/backend/middleware/request_id.go
@@ -1,0 +1,51 @@
+package middleware
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	contextKeyRequestID = "request_id"
+	headerKeyRequestID  = "X-Request-ID"
+)
+
+func RequestIDMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		id, err := newUUIDv4()
+		if err != nil {
+			// fallback
+			id = "00000000-0000-4000-8000-000000000000"
+		}
+		c.Set(contextKeyRequestID, id)
+		c.Writer.Header().Set(headerKeyRequestID, id)
+		c.Next()
+	}
+}
+
+func newUUIDv4() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+
+	// RFC4122: version 4
+	b[6] = (b[6] & 0x0f) | 0x40
+	// RFC4122: variant 10xx
+	b[8] = (b[8] & 0x3f) | 0x80
+
+	dst := make([]byte, 36)
+	hex.Encode(dst[0:8], b[0:4])
+	dst[8] = '-'
+	hex.Encode(dst[9:13], b[4:6])
+	dst[13] = '-'
+	hex.Encode(dst[14:18], b[6:8])
+	dst[18] = '-'
+	hex.Encode(dst[19:23], b[8:10])
+	dst[23] = '-'
+	hex.Encode(dst[24:36], b[10:16])
+
+	return string(dst), nil
+}

--- a/backend/middleware/request_id_test.go
+++ b/backend/middleware/request_id_test.go
@@ -1,0 +1,175 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+var uuidFormatRe = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+func TestRequestIDMiddleware_SingleRequest(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	r.Use(RequestIDMiddleware())
+
+	r.GET("/test", func(c *gin.Context) {
+		requestIDAny, exists := c.Get("request_id")
+		if !exists {
+			t.Fatal("request_id not found in context")
+		}
+
+		requestID, ok := requestIDAny.(string)
+		if !ok {
+			t.Fatalf("request_id is not string: %T", requestIDAny)
+		}
+
+		c.JSON(http.StatusOK, gin.H{"request_id": requestID})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status mismatch: got=%d want=%d", w.Code, http.StatusOK)
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode response :%v", err)
+	}
+
+	id := body["request_id"]
+	if id == "" {
+		t.Fatal("request_id is empty")
+	}
+	if !uuidFormatRe.MatchString(id) {
+		t.Fatalf("request_id is not UUID format: %s", id)
+	}
+}
+
+func TestRequestIDMiddleware_DifferentIDPerRequest(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	r.Use(RequestIDMiddleware())
+	r.GET("/test", func(c *gin.Context) {
+		requestIDAny, exists := c.Get("request_id")
+		if !exists {
+			t.Fatal("request_id not found in context")
+		}
+
+		requestID, ok := requestIDAny.(string)
+		if !ok {
+			t.Fatalf("request_id is not string: %T", requestIDAny)
+		}
+
+		c.JSON(http.StatusOK, gin.H{"request_id": requestID})
+	})
+
+	getID := func(t *testing.T) string {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status mismatch: got=%d want=%d", w.Code, http.StatusOK)
+		}
+		var body map[string]string
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("failed to decode response: %v", err)
+		}
+
+		id := body["request_id"]
+		if id == "" {
+			t.Fatal("request_id is empty")
+		}
+		if !uuidFormatRe.MatchString(id) {
+			t.Fatalf("request_id is not UUID format: %s", id)
+		}
+		return id
+	}
+
+	id1 := getID(t)
+	id2 := getID(t)
+
+	if id1 == id2 {
+		t.Fatalf("request_id must be dirrefent across requests: id1=%s id2=%s", id1, id2)
+	}
+}
+
+func TestRequestIDMiddleware_IDIsStableInNextHandler(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	r.Use(RequestIDMiddleware())
+
+	r.GET("/chain",
+		func(c *gin.Context) {
+			requestIDAny, exists := c.Get("request_id")
+			if !exists {
+				t.Fatal("request_id not found in context(first handler)")
+			}
+
+			requestID, ok := requestIDAny.(string)
+			if !ok {
+				t.Fatalf("request_id is not string in first handler: %T", requestIDAny)
+			}
+			c.Set("first_seen_request_id", requestID)
+			c.Next()
+		},
+		func(c *gin.Context) {
+			firstAny, exists := c.Get("first_seen_request_id")
+			if !exists {
+				t.Fatal("first_seen_request_id not found")
+			}
+			firstID, ok := firstAny.(string)
+			if !ok {
+				t.Fatalf("first_seen_request_id is not string:%T", firstAny)
+			}
+
+			currentAny, exists := c.Get("request_id")
+			if !exists {
+				t.Fatal("request_id not found in context(second handler)")
+			}
+			currentID, ok := currentAny.(string)
+			if !ok {
+				t.Fatalf("request_id is not string in second handler: %T", currentAny)
+			}
+			c.JSON(http.StatusOK, gin.H{"first_seen_request_id": firstID, "current_seen_request_id": currentID})
+		},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/chain", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status mismatch: got=%d want=%d", w.Code, http.StatusOK)
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	firstID := body["first_seen_request_id"]
+	currentID := body["current_seen_request_id"]
+
+	if firstID == "" || currentID == "" {
+		t.Fatalf("request_id must not be empty: first=%s current=%s", firstID, currentID)
+	}
+	if firstID != currentID {
+		t.Fatalf("request_id changed in next handler: first=%s current=%s", firstID, currentID)
+	}
+}


### PR DESCRIPTION
Close #75 

概要
- ログに使用するrequest_idの発行を行うミドルウェアを追加
- request_idのフォーマットはUUIDv4形式

変更内容
- request_idをコンテキストに格納するミドルウェア`middleware/request_id.go`の実装とテスト追加
- ルーター起動後最初にrequest_idを発行するように`main.go`を修正