### PR TITLE
Feat: 通常イベントログ(INFO)の出力

### DIFF
--- a/backend/handler/cart.go
+++ b/backend/handler/cart.go
@@ -2,9 +2,11 @@ package handler
 
 import (
 	"database/sql"
+	"log/slog"
 	"net/http"
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/pkg/apperror"
+	"sol_coffeesys/backend/pkg/logging"
 	"strconv"
 	"time"
 
@@ -54,6 +56,12 @@ func GetCartHandler(q db.Querier) gin.HandlerFunc {
 			})
 		}
 		c.JSON(http.StatusOK, gin.H{"items": items})
+
+		logging.LogEvent(c, logging.EventInput{
+			Event:  "cart_items_listed",
+			Status: http.StatusOK,
+			Level:  slog.LevelInfo,
+		})
 	}
 }
 
@@ -121,6 +129,12 @@ func AddToCartHandler(q db.Querier) gin.HandlerFunc {
 		}
 
 		c.JSON(http.StatusCreated, gin.H{"item": item})
+
+		logging.LogEvent(c, logging.EventInput{
+			Event:  "cart_item_added",
+			Status: http.StatusCreated,
+			Level:  slog.LevelInfo,
+		})
 	}
 }
 
@@ -181,6 +195,12 @@ func UpdateCartItemHandler(q db.Querier) gin.HandlerFunc {
 		}
 
 		c.JSON(http.StatusOK, gin.H{"item": item})
+
+		logging.LogEvent(c, logging.EventInput{
+			Event:  "cart_item_updated",
+			Status: http.StatusOK,
+			Level:  slog.LevelInfo,
+		})
 	}
 }
 
@@ -246,6 +266,12 @@ func RemoveCartItemHandler(q db.Querier) gin.HandlerFunc {
 
 		c.Status(http.StatusNoContent)
 
+		logging.LogEvent(c, logging.EventInput{
+			Event:  "cart_item_deleted",
+			Status: http.StatusNoContent,
+			Level:  slog.LevelInfo,
+		})
+
 	}
 }
 
@@ -275,5 +301,11 @@ func ClearCartHandler(q db.Querier) gin.HandlerFunc {
 		}
 
 		c.Status(http.StatusNoContent)
+
+		logging.LogEvent(c, logging.EventInput{
+			Event:  "cart_cleared",
+			Status: http.StatusNoContent,
+			Level:  slog.LevelInfo,
+		})
 	}
 }

--- a/backend/handler/category.go
+++ b/backend/handler/category.go
@@ -2,9 +2,11 @@ package handler
 
 import (
 	"database/sql"
+	"log/slog"
 	"net/http"
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/pkg/apperror"
+	"sol_coffeesys/backend/pkg/logging"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -61,6 +63,12 @@ func CreateCategoryHandler(queries db.Querier) gin.HandlerFunc {
 			ID:          category.ID,
 			Name:        category.Name,
 			Description: responseDescription,
+		})
+
+		logging.LogEvent(c, logging.EventInput{
+			Event:  "category_created",
+			Status: http.StatusCreated,
+			Level:  slog.LevelInfo,
 		})
 	}
 }
@@ -124,6 +132,12 @@ func UpdateCategoryHandler(queries db.Querier) gin.HandlerFunc {
 			Description: responseDescription,
 		})
 
+		logging.LogEvent(c, logging.EventInput{
+			Event:  "category_updated",
+			Status: http.StatusOK,
+			Level:  slog.LevelInfo,
+		})
+
 	}
 }
 
@@ -148,6 +162,12 @@ func GetCategoriesHandler(queries db.Querier) gin.HandlerFunc {
 			})
 		}
 		c.JSON(http.StatusOK, gin.H{"categories": resp})
+
+		logging.LogEvent(c, logging.EventInput{
+			Event:  "categories_listed",
+			Status: http.StatusOK,
+			Level:  slog.LevelInfo,
+		})
 	}
 }
 
@@ -171,5 +191,11 @@ func DeleteCategoryHandler(queries db.Querier) gin.HandlerFunc {
 		}
 
 		c.JSON(http.StatusNoContent, nil)
+
+		logging.LogEvent(c, logging.EventInput{
+			Event:  "category_deleted",
+			Status: http.StatusNoContent,
+			Level:  slog.LevelInfo,
+		})
 	}
 }

--- a/backend/handler/logout.go
+++ b/backend/handler/logout.go
@@ -5,9 +5,11 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"errors"
+	"log/slog"
 	"net/http"
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/pkg/apperror"
+	"sol_coffeesys/backend/pkg/logging"
 
 	"github.com/gin-gonic/gin"
 )
@@ -39,6 +41,13 @@ func LogoutHandler(queries db.Querier) gin.HandlerFunc {
 			http.SetCookie(c.Writer, clearAccess)
 			http.SetCookie(c.Writer, clearRefresh)
 			c.JSON(http.StatusOK, gin.H{"message": "ログアウトしました"})
+
+			logging.LogEvent(c, logging.EventInput{
+				Event:  "auth_logout_succeeded",
+				Status: http.StatusOK,
+				Level:  slog.LevelInfo,
+			})
+
 			return
 		}
 
@@ -79,5 +88,11 @@ func LogoutHandler(queries db.Querier) gin.HandlerFunc {
 		http.SetCookie(c.Writer, clearAccess)
 		http.SetCookie(c.Writer, clearRefresh)
 		c.JSON(http.StatusOK, gin.H{"message": "ログアウトしました"})
+
+		logging.LogEvent(c, logging.EventInput{
+			Event:  "auth_logout_succeeded",
+			Status: http.StatusOK,
+			Level:  slog.LevelInfo,
+		})
 	}
 }

--- a/backend/handler/me.go
+++ b/backend/handler/me.go
@@ -2,10 +2,12 @@ package handler
 
 import (
 	"database/sql"
+	"log/slog"
 	"net/http"
 	"sol_coffeesys/backend/auth"
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/pkg/apperror"
+	"sol_coffeesys/backend/pkg/logging"
 	"strconv"
 	"strings"
 
@@ -76,6 +78,14 @@ func MeHandler(q db.Querier) gin.HandlerFunc {
 				"email": user.Email,
 				"role":  user.Role,
 			},
+		})
+
+		c.Set("userID", userID)
+
+		logging.LogEvent(c, logging.EventInput{
+			Event:  "auth_me_fetched",
+			Status: http.StatusOK,
+			Level:  slog.LevelInfo,
 		})
 	}
 }

--- a/backend/handler/order.go
+++ b/backend/handler/order.go
@@ -5,9 +5,11 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/pkg/apperror"
+	"sol_coffeesys/backend/pkg/logging"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -144,6 +146,12 @@ func CreateOrderHandler(conn *sql.DB, queries *db.Queries) gin.HandlerFunc {
 			return
 		}
 		c.JSON(http.StatusCreated, gin.H{"order": order})
+
+		logging.LogEvent(c, logging.EventInput{
+			Event:  "order_created",
+			Status: http.StatusCreated,
+			Level:  slog.LevelInfo,
+		})
 	}
 }
 
@@ -251,6 +259,12 @@ func CancelOrderHandler(conn *sql.DB, queries *db.Queries) gin.HandlerFunc {
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"order": updated})
+
+		logging.LogEvent(c, logging.EventInput{
+			Event:  "order_cancelled",
+			Status: http.StatusOK,
+			Level:  slog.LevelInfo,
+		})
 	}
 }
 
@@ -336,5 +350,11 @@ func GetOrdersHandler(queries db.Querier) gin.HandlerFunc {
 		}
 
 		c.JSON(http.StatusOK, gin.H{"orders": filtered})
+
+		logging.LogEvent(c, logging.EventInput{
+			Event:  "orders_listed",
+			Status: http.StatusOK,
+			Level:  slog.LevelInfo,
+		})
 	}
 }

--- a/backend/handler/product.go
+++ b/backend/handler/product.go
@@ -3,9 +3,11 @@ package handler
 import (
 	"database/sql"
 	"errors"
+	"log/slog"
 	"net/http"
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/pkg/apperror"
+	"sol_coffeesys/backend/pkg/logging"
 	"strconv"
 	"time"
 
@@ -73,6 +75,12 @@ func ListProductsHandler(q db.Querier) gin.HandlerFunc {
 			})
 		}
 		c.JSON(http.StatusOK, gin.H{"products": resp})
+
+		logging.LogEvent(c, logging.EventInput{
+			Event:  "products_listed",
+			Status: http.StatusOK,
+			Level:  slog.LevelInfo,
+		})
 	}
 }
 
@@ -114,6 +122,12 @@ func GetProductHandler(q db.Querier) gin.HandlerFunc {
 			StockQuantity: product.StockQuantity,
 			CreatedAt:     product.CreatedAt.Format(time.RFC3339),
 			UpdatedAt:     product.UpdatedAt.Format(time.RFC3339),
+		})
+
+		logging.LogEvent(c, logging.EventInput{
+			Event:  "product_fetched",
+			Status: http.StatusOK,
+			Level:  slog.LevelInfo,
 		})
 	}
 }
@@ -204,6 +218,12 @@ func CreateProductHandler(q db.Querier) gin.HandlerFunc {
 			StockQuantity: product.StockQuantity,
 			CreatedAt:     product.CreatedAt.Format(time.RFC3339),
 			UpdatedAt:     product.UpdatedAt.Format(time.RFC3339),
+		})
+
+		logging.LogEvent(c, logging.EventInput{
+			Event:  "product_created",
+			Status: http.StatusCreated,
+			Level:  slog.LevelInfo,
 		})
 	}
 }
@@ -307,6 +327,12 @@ func UpdateProductHandler(q db.Querier) gin.HandlerFunc {
 			CreatedAt:     product.CreatedAt.Format(time.RFC3339),
 			UpdatedAt:     product.UpdatedAt.Format(time.RFC3339),
 		})
+
+		logging.LogEvent(c, logging.EventInput{
+			Event:  "product_updated",
+			Status: http.StatusOK,
+			Level:  slog.LevelInfo,
+		})
 	}
 }
 
@@ -328,5 +354,11 @@ func DeleteProductHandler(q db.Querier) gin.HandlerFunc {
 			return
 		}
 		c.JSON(http.StatusNoContent, nil)
+
+		logging.LogEvent(c, logging.EventInput{
+			Event:  "product_deleted",
+			Status: http.StatusNoContent,
+			Level:  slog.LevelInfo,
+		})
 	}
 }

--- a/backend/handler/refresh.go
+++ b/backend/handler/refresh.go
@@ -5,10 +5,12 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"errors"
+	"log/slog"
 	"net/http"
 	"sol_coffeesys/backend/auth"
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/pkg/apperror"
+	"sol_coffeesys/backend/pkg/logging"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -113,6 +115,13 @@ func RefreshTokenHandler(q db.Querier, tokenGenerator auth.TokenGenerator) gin.H
 			},
 		})
 
+		c.Set("userID", user.ID)
+		logging.LogEvent(c, logging.EventInput{
+			Event:  "auth_refresh_token_updated",
+			Status: http.StatusOK,
+			Level:  slog.LevelInfo,
+		})
+
 	}
 }
 
@@ -143,6 +152,13 @@ func RevokeRefreshHandler(q db.Querier) gin.HandlerFunc {
 			http.SetCookie(c.Writer, clearAccess)
 			http.SetCookie(c.Writer, clearRefresh)
 			c.JSON(http.StatusOK, gin.H{"message": "リフレッシュトークンを破棄しました"})
+
+			logging.LogEvent(c, logging.EventInput{
+				Event:  "auth_refresh_token_revoked",
+				Status: http.StatusOK,
+				Level:  slog.LevelInfo,
+			})
+
 			return
 		}
 
@@ -181,5 +197,11 @@ func RevokeRefreshHandler(q db.Querier) gin.HandlerFunc {
 		http.SetCookie(c.Writer, clearAccess)
 		http.SetCookie(c.Writer, clearRefresh)
 		c.JSON(http.StatusOK, gin.H{"message": "リフレッシュトークンを破棄しました"})
+
+		logging.LogEvent(c, logging.EventInput{
+			Event:  "auth_refresh_token_revoked",
+			Status: http.StatusOK,
+			Level:  slog.LevelInfo,
+		})
 	}
 }

--- a/backend/handler/user.go
+++ b/backend/handler/user.go
@@ -3,11 +3,14 @@ package handler
 import (
 	"database/sql"
 	"errors"
+	"log/slog"
 	"net/http"
 	"sol_coffeesys/backend/auth"
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/pkg/apperror"
+	"sol_coffeesys/backend/pkg/logging"
 	"sol_coffeesys/backend/pkg/validation"
+
 	"strconv"
 	"time"
 
@@ -86,6 +89,13 @@ func RegisterUserHandler(q db.Querier) gin.HandlerFunc {
 
 		// 登録成功		migrate -path db/migrations -database "postgres://user:password@db:5432/coffeesys_db?sslmode=disable" up
 		c.JSON(http.StatusCreated, user)
+
+		c.Set("userID", user.ID)
+		logging.LogEvent(c, logging.EventInput{
+			Event:  "auth_register_succeeded",
+			Status: http.StatusCreated,
+			Level:  slog.LevelInfo,
+		})
 	}
 }
 
@@ -176,6 +186,14 @@ func LoginUserHandler(q db.Querier, tokenGenerator auth.TokenGenerator) gin.Hand
 				"role":  user.Role,
 			},
 		})
+
+		c.Set("userID", user.ID)
+		logging.LogEvent(c, logging.EventInput{
+			Event:  "auth_login_succeeded",
+			Status: http.StatusOK,
+			Level:  slog.LevelInfo,
+		})
+
 	}
 }
 
@@ -228,5 +246,12 @@ func SetUserRoleHandler(q db.Querier) gin.HandlerFunc {
 			return
 		}
 		c.JSON(http.StatusOK, user)
+
+		c.Set("userID", userID)
+		logging.LogEvent(c, logging.EventInput{
+			Event:  "auth_setrole_succeeded",
+			Status: http.StatusOK,
+			Level:  slog.LevelInfo,
+		})
 	}
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -44,6 +44,8 @@ func main() {
 	r.Use(gin.Recovery())
 
 	// 4. ミドルウェア設定
+	// duration_ms
+	r.Use(middleware.RequestStartedAtMiddleware())
 	// request_id生成
 	r.Use(middleware.RequestIDMiddleware())
 

--- a/backend/middleware/error_handler.go
+++ b/backend/middleware/error_handler.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"sol_coffeesys/backend/pkg/apperror"
+	"sol_coffeesys/backend/pkg/logging"
 	"strings"
 	"time"
 
@@ -32,6 +33,12 @@ func redactSensitiveAttr(_ []string, attr slog.Attr) slog.Attr {
 func ErrorHandler(toHTTP func(error) (int, string)) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		startedAt := time.Now()
+		if raw, ok := c.Get(logging.CtxKeyRequestStartedAt); ok {
+			if v, ok := raw.(time.Time); ok {
+				startedAt = v
+			}
+		}
+
 		c.Next()
 
 		if len(c.Errors) == 0 || c.Writer.Written() {

--- a/backend/middleware/request_timing.go
+++ b/backend/middleware/request_timing.go
@@ -1,0 +1,15 @@
+package middleware
+
+import (
+	"sol_coffeesys/backend/pkg/logging"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func RequestStartedAtMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Set(logging.CtxKeyRequestStartedAt, time.Now())
+		c.Next()
+	}
+}

--- a/backend/pkg/logging/eventlog.go
+++ b/backend/pkg/logging/eventlog.go
@@ -1,0 +1,1 @@
+package logging

--- a/backend/pkg/logging/eventlog.go
+++ b/backend/pkg/logging/eventlog.go
@@ -49,3 +49,19 @@ func BuildAttrs(c *gin.Context, in EventInput) []slog.Attr {
 
 	return attrs
 }
+
+func LogEvent(c *gin.Context, in EventInput) {
+	level := in.Level
+
+	if level == 0 {
+		level = slog.LevelInfo
+	}
+
+	msg := in.Message
+	if msg == "" {
+		msg = in.Event
+	}
+
+	attrs := BuildAttrs(c, in)
+	slog.LogAttrs(c.Request.Context(), level, msg, attrs...)
+}

--- a/backend/pkg/logging/eventlog.go
+++ b/backend/pkg/logging/eventlog.go
@@ -1,1 +1,51 @@
 package logging
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func BuildAttrs(c *gin.Context, in EventInput) []slog.Attr {
+	route := c.FullPath()
+	if route == "" && c.Request != nil && c.Request.URL != nil {
+		route = c.Request.URL.Path
+	}
+
+	method := ""
+	if c.Request != nil {
+		method = c.Request.Method
+	}
+
+	attrs := []slog.Attr{
+		slog.String("request_id", c.GetString(CtxKeyRequestID)),
+		slog.String("method", method),
+		slog.String("route", route),
+		slog.Int("status", in.Status),
+		slog.String("event", in.Event),
+	}
+
+	if startedAtRaw, ok := c.Get(CtxKeyRequestStartedAt); ok {
+		if startedAt, ok := startedAtRaw.(time.Time); ok {
+			elapsed := time.Since(startedAt)
+			attrs = append(attrs, slog.Float64("duration_ms", float64(elapsed.Microseconds())/1000))
+		}
+	}
+
+	if rawUserID, ok := c.Get(CtxKeyUserID); ok {
+		if userID, ok := rawUserID.(int64); ok {
+			attrs = append(attrs, slog.Int64("user_id", userID))
+		}
+	}
+
+	if in.Message != "" {
+		attrs = append(attrs, slog.String("message", in.Message))
+	}
+
+	if len(in.Extra) > 0 {
+		attrs = append(attrs, in.Extra...)
+	}
+
+	return attrs
+}

--- a/backend/pkg/logging/eventlog_test.go
+++ b/backend/pkg/logging/eventlog_test.go
@@ -1,0 +1,146 @@
+package logging
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestBuildAttrs_ContainRequireFields(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name              string
+		setupContext      func(*gin.Context)
+		input             EventInput
+		wantRequestID     string
+		wantMethod        string
+		wantRoute         string
+		wantStatus        int
+		wantEvent         string
+		wantUserID        int64
+		wantUserIDPresent bool
+		checkDuration     bool
+	}{
+		{
+			name: "必須フィールドが出る",
+			setupContext: func(c *gin.Context) {
+				c.Request = httptest.NewRequest(http.MethodGet, "/api/login", nil)
+				c.Set(CtxKeyRequestID, "req-1")
+				c.Set(CtxKeyRequestStartedAt, time.Now().Add(-10*time.Millisecond))
+			},
+			input: EventInput{
+				Event:  "auth_login_succeeded",
+				Status: http.StatusOK,
+				Level:  slog.LevelInfo,
+			},
+			wantRequestID:     "req-1",
+			wantMethod:        http.MethodPost,
+			wantRoute:         "/api/login",
+			wantStatus:        http.StatusOK,
+			wantEvent:         "auth_login_succeeded",
+			wantUserIDPresent: false,
+			checkDuration:     true,
+		},
+		{
+			name: "user_idはある時だけ出る",
+			setupContext: func(c *gin.Context) {
+				c.Request = httptest.NewRequest(http.MethodGet, "/api/me", nil)
+				c.Set(CtxKeyRequestID, "req-2")
+				c.Set(CtxKeyRequestStartedAt, time.Now().Add(-10*time.Millisecond))
+				c.Set(CtxKeyUserID, int64(42))
+			},
+			input: EventInput{
+				Event:  "user_profile_fetched",
+				Status: http.StatusOK,
+				Level:  slog.LevelInfo,
+			},
+			wantRequestID:     "req-2",
+			wantMethod:        http.MethodGet,
+			wantRoute:         "/api/me",
+			wantStatus:        http.StatusOK,
+			wantEvent:         "user_profile_fetched",
+			wantUserID:        int64(42),
+			wantUserIDPresent: true,
+			checkDuration:     true,
+		},
+		{
+			name: "started_atが無い時もpanicしない",
+			setupContext: func(c *gin.Context) {
+				c.Request = httptest.NewRequest(http.MethodGet, "/health", nil)
+				c.Set(CtxKeyRequestID, "req-3")
+			},
+			input: EventInput{
+				Event:  "health_checked",
+				Status: http.StatusOK,
+				Level:  slog.LevelInfo,
+			},
+			wantRequestID:     "req-3",
+			wantMethod:        http.MethodGet,
+			wantRoute:         "/health",
+			wantStatus:        http.StatusOK,
+			wantEvent:         "health_checked",
+			wantUserIDPresent: false,
+			checkDuration:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+
+			tt.setupContext(c)
+
+			attrs := BuildAttrs(c, tt.input)
+			got := attrsToMap(attrs)
+
+			if got["request_id"] != tt.wantRequestID {
+				t.Fatalf("request_id mismatch: got=%v want=%v", got["request_id"], tt.wantRequestID)
+			}
+			if got["method"] != tt.wantMethod {
+				t.Fatalf("method mismatch: got=%v want=%v", got["method"], tt.wantMethod)
+			}
+			if got["route"] != tt.wantRoute {
+				t.Fatalf("route mismatch: got=%v want=%v", got["route"], tt.wantRoute)
+			}
+			if got["status"] != tt.wantStatus {
+				t.Fatalf("status mismatch: got=%v want=%v", got["status"], tt.wantStatus)
+			}
+			if got["event"] != tt.wantEvent {
+				t.Fatalf("event mismatch: got=%v want=%v", got["event"], tt.wantEvent)
+			}
+
+			rawUserID, exists := got["user_id"]
+			if exists != tt.wantUserIDPresent {
+				t.Fatalf("user_id presence mismatch: got=%v want=%v", exists, tt.wantUserIDPresent)
+			}
+			if tt.wantUserIDPresent && rawUserID != tt.wantUserID {
+				t.Fatalf("user_id mismatch: got=%v want=%v", rawUserID, tt.wantUserID)
+			}
+
+			if tt.checkDuration {
+				durationMS, ok := got["duration_ms"].(float64)
+				if !ok {
+					t.Fatalf("duration_ms type mismatch: got=%T", got["duration_ms"])
+				}
+				if durationMS < 0 {
+					t.Fatalf("duration_ms should not be negative: got=%v", durationMS)
+				}
+			}
+
+		})
+	}
+}
+
+func attrsToMap(attrs []slog.Attr) map[string]any {
+	result := make(map[string]any, len(attrs))
+	for _, attr := range attrs {
+		result[attr.Key] = attr.Value.Any()
+	}
+	return result
+}

--- a/backend/pkg/logging/eventlog_test.go
+++ b/backend/pkg/logging/eventlog_test.go
@@ -1,6 +1,8 @@
 package logging
 
 import (
+	"bytes"
+	"encoding/json"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -147,4 +149,80 @@ func attrsToMap(attrs []slog.Attr) map[string]any {
 		result[attr.Key] = attr.Value.Any()
 	}
 	return result
+}
+
+func TestLogEvent_UsesEventAsMessageWhenMessageEmpty(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	orig := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(orig) })
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	slog.SetDefault(logger)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/login", nil)
+	c.Set(CtxKeyRequestID, "req-1")
+	c.Set(CtxKeyRequestStartedAt, time.Now().Add(-10*time.Millisecond))
+	c.Set(CtxKeyUserID, int64(42))
+
+	LogEvent(c, EventInput{
+		Event:  "auth_login_succeeded",
+		Status: http.StatusOK,
+		Level:  slog.LevelInfo,
+		// Messageは空
+	})
+
+	var got map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("failed to decode log json: %v raw=%s", err, buf.String())
+	}
+
+	// slogのmessageキーは "msg"
+	if got["msg"] != "auth_login_succeeded" {
+		t.Fatalf("msg mismatch: got=%v want=%v", got["msg"], "auth_login_succeeded")
+	}
+	if got["event"] != "auth_login_succeeded" {
+		t.Fatalf("event mismatch: got=%v want=%v", got["event"], "auth_login_succeeded")
+	}
+	if got["request_id"] != "req-1" {
+		t.Fatalf("request_id mismatch: got=%v want=%v", got["request_id"], "req-1")
+	}
+}
+
+func TestLogEvent_DefaultLevelInfoWhenLevelNotSpecified(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	orig := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(orig) })
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	slog.SetDefault(logger)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/health", nil)
+	c.Set(CtxKeyRequestID, "req-2")
+	c.Set(CtxKeyRequestStartedAt, time.Now().Add(-5*time.Millisecond))
+
+	// Level未指定（ゼロ値）
+	LogEvent(c, EventInput{
+		Event:  "health_checked",
+		Status: http.StatusOK,
+	})
+
+	var got map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("failed to decode log json: %v raw=%s", err, buf.String())
+	}
+
+	if got["level"] != "INFO" {
+		t.Fatalf("level mismatch: got=%v want=INFO", got["level"])
+	}
+	if got["msg"] != "health_checked" {
+		t.Fatalf("msg mismatch: got=%v want=health_checked", got["msg"])
+	}
 }

--- a/backend/pkg/logging/eventlog_test.go
+++ b/backend/pkg/logging/eventlog_test.go
@@ -39,7 +39,7 @@ func TestBuildAttrs_ContainRequireFields(t *testing.T) {
 				Level:  slog.LevelInfo,
 			},
 			wantRequestID:     "req-1",
-			wantMethod:        http.MethodPost,
+			wantMethod:        http.MethodGet,
 			wantRoute:         "/api/login",
 			wantStatus:        http.StatusOK,
 			wantEvent:         "auth_login_succeeded",
@@ -108,7 +108,11 @@ func TestBuildAttrs_ContainRequireFields(t *testing.T) {
 			if got["route"] != tt.wantRoute {
 				t.Fatalf("route mismatch: got=%v want=%v", got["route"], tt.wantRoute)
 			}
-			if got["status"] != tt.wantStatus {
+			gotStatus, ok := got["status"].(int64)
+			if !ok {
+				t.Fatalf("status type mismatch: got=%T", got["status"])
+			}
+			if int(gotStatus) != tt.wantStatus {
 				t.Fatalf("status mismatch: got=%v want=%v", got["status"], tt.wantStatus)
 			}
 			if got["event"] != tt.wantEvent {

--- a/backend/pkg/logging/requestmeta.go
+++ b/backend/pkg/logging/requestmeta.go
@@ -1,0 +1,19 @@
+package logging
+
+import (
+	"log/slog"
+)
+
+const (
+	CtxKeyRequestStartedAt = "request_started_at"
+	CtxKeyRequestID        = "request_id"
+	CtxKeyUserID           = "userID"
+)
+
+type EventInput struct {
+	Event   string
+	Status  int
+	Message string // optional
+	Level   slog.Level
+	Extra   []slog.Attr
+}

--- a/doc/memo/2026/05/31_learning.md
+++ b/doc/memo/2026/05/31_learning.md
@@ -1,0 +1,36 @@
+# 学習記録 2026-05-31
+
+## セッション 1
+
+### 取り組んだタスク
+- **Ticket F 実装前半**: 通常イベントログ基盤の実装
+  - `backend/pkg/logging` に `EventInput` / `BuildAttrs` / `LogEvent` を実装
+  - `BuildAttrs` のテーブル駆動テスト作成・修正（status型の int/int64 差異を解消）
+  - `LogEvent` の挙動テスト追加（message空時はeventをmsgにフォールバック、level未指定はINFO）
+  - `middleware/request_timing.go` を追加し `request_started_at` を Context 保存
+  - `main.go` に `RequestStartedAtMiddleware` を最上流で適用
+  - `handler/user.go` の `LoginUserHandler` 成功終端に `logging.LogEvent` を注入
+
+### ユーザーが質問した内容
+（記載なし）
+
+### 躓いたポイントと解決策
+
+#### status型の int/int64 差異
+- **原因**: BuildAttrs のテーブル駆動テスト内で status が期待と異なる型であった
+- **解決策**: テスト設定を修正し、型の整合性を確保した
+
+#### duration_ms の意味の確認
+- **原因**: duration_ms がサーバー起動からの経過なのか、リクエスト開始からの経過なのか明確でなかった
+- **解決策**: 仕様確認によりリクエスト開始から の経過時間であることを確認
+
+### 次回課題
+- 通常イベントログの横展開：ログイン成功以外のエンドポイントへの適用
+- 異常系イベントログの実装（ErrorHandler 集約による実装）
+- 実装完了後の統合テスト
+
+### 設計判断と考慮事項
+- **Context キーの統一**: userID を既存整合に優先し維持、ログフィールドは user_id で出力
+- **request_id の扱い**: 現状維持
+- **request_timing ミドルウェアのテスト**: 薄い実装のため単体テスト当面省略、既存統合テストで間接担保
+- **正常系/異常系の出力ポイント**: 正常系はハンドラ終端で出力、異常系は ErrorHandler に集約


### PR DESCRIPTION
refer #85 

### 概要
- 通常イベントログ用のヘルパー関数の作成
- 各ハンドラの終端でINFOログを出力


### 変更
- `duration_ms`を、通常イベント/エラーハンドラで共通利用するためのミドルウェアに移動
- ログインやトークン処理などのハンドラでコンテキストにuserIDを含める処理を追加
