### PR TITLE
fix(auth): /api/me の認証を RequireAuth に移行

### DIFF
--- a/backend/handler/me.go
+++ b/backend/handler/me.go
@@ -4,56 +4,36 @@ import (
 	"database/sql"
 	"log/slog"
 	"net/http"
-	"sol_coffeesys/backend/auth"
 	"sol_coffeesys/backend/db"
 	"sol_coffeesys/backend/pkg/apperror"
 	"sol_coffeesys/backend/pkg/logging"
 	"strconv"
-	"strings"
 
 	"github.com/gin-gonic/gin"
-	"github.com/golang-jwt/jwt/v5"
 )
 
 func MeHandler(q db.Querier) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		authHeader := c.GetHeader("Authorization")
-		if authHeader == "" {
+		raw, exist := c.Get("userID")
+		if !exist {
 			_ = c.Error(apperror.NewUnauthorizedError("token_not_found", apperror.UnauthorizedMessageAuth))
-			return
-		}
-		parts := strings.SplitN(authHeader, " ", 2)
-		if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
-			_ = c.Error(apperror.NewUnauthorizedError("invalid_format_token", apperror.UnauthorizedMessageAuth))
-			return
-		}
-		tokenStr := parts[1]
-
-		token, err := auth.Validate(tokenStr)
-		if err != nil || token == nil || !token.Valid {
-			_ = c.Error(apperror.NewUnauthorizedError("invalid_token", apperror.UnauthorizedMessageAuth))
-			return
-		}
-
-		claims, ok := token.Claims.(jwt.MapClaims)
-		if !ok {
-			_ = c.Error(apperror.NewUnauthorizedError("failed_to_decode_token", apperror.UnauthorizedMessageAuth))
-			return
-		}
-
-		rawID, ok := claims["user.id"]
-		if !ok {
-			_ = c.Error(apperror.NewUnauthorizedError("userID_claims_not_found", apperror.UnauthorizedMessageAuth))
 			return
 		}
 
 		var userID int64
-		switch v := rawID.(type) {
+
+		switch v := raw.(type) {
+		case int:
+			userID = int64(v)
+		case int32:
+			userID = int64(v)
+		case int64:
+			userID = v
 		case float64:
 			userID = int64(v)
 		case string:
-			id, perr := strconv.ParseInt(v, 10, 64)
-			if perr != nil {
+			id, err := strconv.ParseInt(v, 10, 64)
+			if err != nil {
 				_ = c.Error(apperror.NewUnauthorizedError("userID_parse_failed", apperror.UnauthorizedMessageAuth))
 				return
 			}
@@ -71,6 +51,7 @@ func MeHandler(q db.Querier) gin.HandlerFunc {
 			_ = c.Error(apperror.NewInternalError("GetUserForUpdate", err, apperror.InternalServerMessageCommon))
 			return
 		}
+
 		c.JSON(http.StatusOK, gin.H{
 			"user": gin.H{
 				"id":    user.ID,

--- a/backend/handler/me_test.go
+++ b/backend/handler/me_test.go
@@ -1,20 +1,14 @@
-package handler_test
+package handler
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"sol_coffeesys/backend/auth"
 	"sol_coffeesys/backend/db"
-	"sol_coffeesys/backend/handler"
-	testutil "sol_coffeesys/backend/handler/testutil"
-	"sol_coffeesys/backend/middleware"
-	"sol_coffeesys/backend/pkg/apperror"
+	"sol_coffeesys/backend/handler/testutil"
 	"testing"
 
 	"github.com/gin-gonic/gin"
-	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -22,229 +16,60 @@ import (
 func TestMeHandler(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	origValidate := auth.Validate
-	t.Cleanup(func() {
-		auth.Validate = origValidate
-	})
-
 	tests := []struct {
-		name         string
-		authHeader   string
-		validateFunc func(string) (*jwt.Token, error)
-		setupMock    func(m *testutil.MockDB)
-		expectStatus int
-		checkBody    func(t *testing.T, body []byte)
+		name           string
+		userID         any
+		setupMock      func(*testutil.MockDB)
+		expectedStatus int
+		checkResponse  func(*testing.T, *httptest.ResponseRecorder)
 	}{
 		{
-			name:       "正常系：有効トークン",
-			authHeader: "Bearer valid",
-			validateFunc: func(ts string) (*jwt.Token, error) {
-				return &jwt.Token{Valid: true, Claims: jwt.MapClaims{"user.id": float64(1)}}, nil
-			},
+			name:   "正常系：userIDからプロフィールを取得して返す",
+			userID: int64(1),
 			setupMock: func(m *testutil.MockDB) {
-				m.On("GetUserForUpdate", mock.Anything, int64(1)).Return(db.User{ID: 1, Name: "Taro", Email: "taro@example.com"}, nil)
+				m.On("GetUserForUpdate", mock.Anything, int64(1)).
+					Return(db.User{
+						ID:    1,
+						Name:  "Taro",
+						Email: "taro@example.com",
+						Role:  "member",
+					}, nil)
 			},
-			expectStatus: http.StatusOK,
-			checkBody: func(t *testing.T, body []byte) {
-				var resp map[string]interface{}
-				assert.NoError(t, json.Unmarshal(body, &resp))
-				user, ok := resp["user"].(map[string]interface{})
+			expectedStatus: http.StatusOK,
+			checkResponse: func(t *testing.T, w *httptest.ResponseRecorder) {
+				var response map[string]any
+				err := json.Unmarshal(w.Body.Bytes(), &response)
+				assert.NoError(t, err)
+				user, ok := response["user"].(map[string]any)
 				assert.True(t, ok)
+				assert.Equal(t, float64(1), user["id"])
+				assert.Equal(t, "Taro", user["name"])
 				assert.Equal(t, "taro@example.com", user["email"])
-			},
-		},
-		{
-			name:       "クレームが数字文字列->200",
-			authHeader: "Bearer valid",
-			validateFunc: func(ts string) (*jwt.Token, error) {
-				return &jwt.Token{Valid: true, Claims: jwt.MapClaims{"user.id": "1"}}, nil
-			},
-			setupMock: func(m *testutil.MockDB) {
-				m.On("GetUserForUpdate", mock.Anything, int64(1)).Return(db.User{ID: 1, Name: "Taro", Email: "taro@example.com"}, nil)
-			},
-			expectStatus: http.StatusOK,
-			checkBody: func(t *testing.T, body []byte) {
-				var resp map[string]interface{}
-				assert.NoError(t, json.Unmarshal(body, &resp))
-				user, ok := resp["user"].(map[string]interface{})
-				assert.True(t, ok)
-				assert.Equal(t, "taro@example.com", user["email"])
-			},
-		},
-		{
-			name:         "ヘッダ無し->401",
-			authHeader:   "",
-			validateFunc: nil,
-			setupMock:    nil,
-			expectStatus: http.StatusUnauthorized,
-			checkBody: func(t *testing.T, body []byte) {
-				var resp map[string]interface{}
-				assert.NoError(t, json.Unmarshal(body, &resp))
-				_, ok := resp["error"]
-				assert.True(t, ok)
-			},
-		},
-		{
-			name:         "ヘッダフォーマット不正->401",
-			authHeader:   "invalidHeader",
-			validateFunc: nil,
-			setupMock:    nil,
-			expectStatus: http.StatusUnauthorized,
-			checkBody: func(t *testing.T, body []byte) {
-				var resp map[string]interface{}
-				assert.NoError(t, json.Unmarshal(body, &resp))
-				_, ok := resp["error"]
-				assert.True(t, ok)
-			},
-		},
-		{
-			name:       "無効なトークン（Validateエラー）->401",
-			authHeader: "Bearer invalid",
-			validateFunc: func(ts string) (*jwt.Token, error) {
-				return nil, fmt.Errorf("invalid")
-			},
-			setupMock:    nil,
-			expectStatus: http.StatusUnauthorized,
-			checkBody: func(t *testing.T, body []byte) {
-				var resp map[string]interface{}
-				assert.NoError(t, json.Unmarshal(body, &resp))
-				_, ok := resp["error"]
-				assert.True(t, ok)
-			},
-		}, {
-			name:       "トークン欠落->401",
-			authHeader: "Bearer",
-			validateFunc: func(ts string) (*jwt.Token, error) {
-				return nil, fmt.Errorf("invalid")
-			},
-			setupMock:    nil,
-			expectStatus: http.StatusUnauthorized,
-			checkBody: func(t *testing.T, body []byte) {
-				var resp map[string]interface{}
-				assert.NoError(t, json.Unmarshal(body, &resp))
-				_, ok := resp["error"]
-				assert.True(t, ok)
-			},
-		},
-		{
-			name:         "クレームなし->401",
-			authHeader:   "Bearer noclaim",
-			validateFunc: func(ts string) (*jwt.Token, error) { return &jwt.Token{Valid: true, Claims: jwt.MapClaims{}}, nil },
-			setupMock:    nil,
-			expectStatus: http.StatusUnauthorized,
-			checkBody: func(t *testing.T, body []byte) {
-				var resp map[string]interface{}
-				assert.NoError(t, json.Unmarshal(body, &resp))
-				_, ok := resp["error"]
-				assert.True(t, ok)
-			},
-		},
-		{
-			name:       "クレームの型が不正（bool）->401",
-			authHeader: "Bearer noclaim",
-			validateFunc: func(ts string) (*jwt.Token, error) {
-				return &jwt.Token{Valid: true, Claims: jwt.MapClaims{"user.id": true}}, nil
-			},
-			setupMock:    nil,
-			expectStatus: http.StatusUnauthorized,
-			checkBody: func(t *testing.T, body []byte) {
-				var resp map[string]interface{}
-				assert.NoError(t, json.Unmarshal(body, &resp))
-				_, ok := resp["error"]
-				assert.True(t, ok)
-			},
-		},
-		{
-			name:       "token.Validがfalse->401",
-			authHeader: "Bearer noclaim",
-			validateFunc: func(ts string) (*jwt.Token, error) {
-				return &jwt.Token{Valid: false, Claims: jwt.MapClaims{"user.id": float64(1)}}, nil
-			},
-			setupMock:    nil,
-			expectStatus: http.StatusUnauthorized,
-			checkBody: func(t *testing.T, body []byte) {
-				var resp map[string]interface{}
-				assert.NoError(t, json.Unmarshal(body, &resp))
-				_, ok := resp["error"]
-				assert.True(t, ok)
-			},
-		},
-		{
-			name:       "ユーザー未検出->401",
-			authHeader: "Bearer missing",
-			validateFunc: func(ts string) (*jwt.Token, error) {
-				return &jwt.Token{Valid: true, Claims: jwt.MapClaims{}}, nil
-			},
-			setupMock:    nil,
-			expectStatus: http.StatusUnauthorized,
-			checkBody: func(t *testing.T, body []byte) {
-				var resp map[string]interface{}
-				assert.NoError(t, json.Unmarshal(body, &resp))
-				_, ok := resp["error"]
-				assert.True(t, ok)
-			},
-		},
-		{
-			name:       "トークン型アサーション失敗->401",
-			authHeader: "Bearer missing",
-			validateFunc: func(ts string) (*jwt.Token, error) {
-				return &jwt.Token{Valid: true, Claims: jwt.RegisteredClaims{}}, nil
-			},
-			setupMock:    nil,
-			expectStatus: http.StatusUnauthorized,
-			checkBody: func(t *testing.T, body []byte) {
-				var resp map[string]interface{}
-				assert.NoError(t, json.Unmarshal(body, &resp))
-				_, ok := resp["error"]
-				assert.True(t, ok)
-			},
-		},
-		{
-			name:       "DBエラー->500",
-			authHeader: "Bearer dberr",
-			validateFunc: func(ts string) (*jwt.Token, error) {
-				return &jwt.Token{Valid: true, Claims: jwt.MapClaims{"user.id": float64(2)}}, nil
-			},
-			setupMock: func(m *testutil.MockDB) {
-				m.On("GetUserForUpdate", mock.Anything, int64(2)).Return(db.User{}, fmt.Errorf("db error"))
-			},
-			expectStatus: http.StatusInternalServerError,
-			checkBody: func(t *testing.T, body []byte) {
-				var resp map[string]interface{}
-				assert.NoError(t, json.Unmarshal(body, &resp))
-				_, ok := resp["error"]
-				assert.True(t, ok)
+				assert.Equal(t, "member", user["role"])
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.validateFunc != nil {
-				auth.Validate = tt.validateFunc
-			} else {
-				auth.Validate = origValidate
-			}
 			router := gin.New()
-			router.Use(middleware.ErrorHandler(apperror.ToHTTP))
 			mockDB := new(testutil.MockDB)
 			if tt.setupMock != nil {
 				tt.setupMock(mockDB)
 			}
-
-			router.GET("/api/me", handler.MeHandler(mockDB))
+			router.GET("/api/me", func(c *gin.Context) {
+				c.Set("userID", tt.userID)
+				MeHandler(mockDB)(c)
+			})
 
 			req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
-			if tt.authHeader != "" {
-				req.Header.Set("Authorization", tt.authHeader)
-			}
 			w := httptest.NewRecorder()
 			router.ServeHTTP(w, req)
-			assert.Equal(t, tt.expectStatus, w.Code)
-			if tt.checkBody != nil {
-				tt.checkBody(t, w.Body.Bytes())
-			}
 
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			if tt.checkResponse != nil {
+				tt.checkResponse(t, w)
+			}
 			mockDB.AssertExpectations(t)
 		})
 	}

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -35,7 +35,7 @@ func SetupRoutes(r *gin.Engine, conn *sql.DB, queries *db.Queries) {
 		api.DELETE("/cart/items/:id", auth.RequireAuth(queries), handler.RemoveCartItemHandler(queries))
 		api.DELETE("/cart", auth.RequireAuth(queries), handler.ClearCartHandler(queries))
 
-		api.GET("/me", handler.MeHandler(queries))
+		api.GET("/me", auth.RequireAuth(queries), handler.MeHandler(queries))
 
 		api.GET("/orders", auth.RequireAuth(queries), handler.GetOrdersHandler(queries))
 		api.POST("/orders", auth.RequireAuth(queries), handler.CreateOrderHandler(conn, queries))


### PR DESCRIPTION
## 概要
- ロギング実装の動作確認中に、Adminアカウントで管理者ページにアクセスしようとしたところ、強制ログアウトにリダイレクトされた
- 原因を調査したところフロント側で/api/meでプロフィール取得しに行った際にエラーとなっていた
- MeハンドラはAuthRequireミドルウェアよりも前に実装されており、共通認証基盤を使用しない独自認証判定をしていたため、localstorage -> cookieの移行時にマイグレーション対象として漏れたのが原因

## 修正内容
- Meハンドラがauthミドルウェアを使うようにroutesを修正
- MeハンドラのBearer認証確認をミドルウェア依存にしたため削除